### PR TITLE
qtpy适配，修改依赖项

### DIFF
--- a/examples/acrylic_label/demo.py
+++ b/examples/acrylic_label/demo.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 import sys
 
-from PyQt5.QtGui import QColor
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QApplication
 
 from qfluentwidgets.components.widgets.acrylic_label import AcrylicLabel
 

--- a/examples/button/demo.py
+++ b/examples/button/demo.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 import sys
 
-from PyQt5.QtCore import Qt, QSize
-from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout
+from qtpy.QtCore import Qt, QSize
+from qtpy.QtWidgets import QApplication, QWidget, QVBoxLayout
 from qfluentwidgets import PushButton, PrimaryPushButton, HyperlinkButton, setTheme, Theme, ToolButton
 from qfluentwidgets import FluentIcon as FIF
 

--- a/examples/check_box/demo.py
+++ b/examples/check_box/demo.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget
 
 from qfluentwidgets import CheckBox
 

--- a/examples/color_dialog/demo.py
+++ b/examples/color_dialog/demo.py
@@ -1,9 +1,9 @@
 # coding:utf-8
 import sys
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor
-from PyQt5.QtWidgets import QApplication, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QApplication, QWidget
 from qfluentwidgets import ColorPickerButton, setTheme, Theme
 
 

--- a/examples/combo_box/demo.py
+++ b/examples/combo_box/demo.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget, QHBoxLayout
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget, QHBoxLayout
 from qfluentwidgets import ComboBox, setTheme, Theme, setThemeColor
 
 class Demo(QWidget):

--- a/examples/dialog/demo.py
+++ b/examples/dialog/demo.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget
 
 from qfluentwidgets import Dialog, setTheme, Theme, PrimaryPushButton
 

--- a/examples/flow_layout/demo.py
+++ b/examples/flow_layout/demo.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import QEasingCurve
-from PyQt5.QtWidgets import QApplication, QWidget, QPushButton
+from qtpy.QtCore import QEasingCurve
+from qtpy.QtWidgets import QApplication, QWidget, QPushButton
 
 from qfluentwidgets import FlowLayout
 

--- a/examples/folder_list_dialog/demo.py
+++ b/examples/folder_list_dialog/demo.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget
 
 from qfluentwidgets import FolderListDialog, setTheme, Theme, PrimaryPushButton
 

--- a/examples/gallery/app/common/signal_bus.py
+++ b/examples/gallery/app/common/signal_bus.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from PyQt5.QtCore import QObject, pyqtSignal
+from qtpy.QtCore import QObject, pyqtSignal
 
 
 class SignalBus(QObject):

--- a/examples/gallery/app/common/translator.py
+++ b/examples/gallery/app/common/translator.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from PyQt5.QtCore import QObject
+from qtpy.QtCore import QObject
 
 
 class Translator(QObject):

--- a/examples/gallery/app/components/avatar_widget.py
+++ b/examples/gallery/app/components/avatar_widget.py
@@ -1,6 +1,6 @@
 # coding: utf-8
-from PyQt5.QtCore import Qt, QRect
-from PyQt5.QtGui import QPainter, QImage, QBrush, QColor, QFont
+from qtpy.QtCore import Qt, QRect
+from qtpy.QtGui import QPainter, QImage, QBrush, QColor, QFont
 from qfluentwidgets import NavigationWidget, isDarkTheme
 
 

--- a/examples/gallery/app/components/link_card.py
+++ b/examples/gallery/app/components/link_card.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import Qt, pyqtSignal, QUrl
-from PyQt5.QtGui import QPixmap, QDesktopServices
-from PyQt5.QtWidgets import QFrame, QLabel, QVBoxLayout, QWidget, QHBoxLayout
+from qtpy.QtCore import Qt, pyqtSignal, QUrl
+from qtpy.QtGui import QPixmap, QDesktopServices
+from qtpy.QtWidgets import QFrame, QLabel, QVBoxLayout, QWidget, QHBoxLayout
 
 from qfluentwidgets import IconWidget, FluentIcon, TextWrap, isDarkTheme, ScrollArea
 from ..common.config import cfg

--- a/examples/gallery/app/components/sample_card.py
+++ b/examples/gallery/app/components/sample_card.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import QWidget, QFrame, QLabel, QVBoxLayout, QHBoxLayout
+from qtpy.QtCore import Qt, pyqtSignal
+from qtpy.QtGui import QPixmap
+from qtpy.QtWidgets import QWidget, QFrame, QLabel, QVBoxLayout, QHBoxLayout
 
 from qfluentwidgets import IconWidget, TextWrap, FlowLayout, isDarkTheme
 from ..common.signal_bus import signalBus

--- a/examples/gallery/app/view/dialog_interface.py
+++ b/examples/gallery/app/view/dialog_interface.py
@@ -1,5 +1,5 @@
 # coding:utf-8
-from PyQt5.QtCore import Qt
+from qtpy.QtCore import Qt
 
 from qfluentwidgets import PushButton, Dialog, MessageBox, ColorDialog
 from ..common.translator import Translator

--- a/examples/gallery/app/view/gallery_interface.py
+++ b/examples/gallery/app/view/gallery_interface.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import Qt, pyqtSignal, QUrl, QEvent
-from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtWidgets import QWidget, QLabel, QVBoxLayout, QHBoxLayout, QFrame
+from qtpy.QtCore import Qt, pyqtSignal, QUrl, QEvent
+from qtpy.QtGui import QDesktopServices
+from qtpy.QtWidgets import QWidget, QLabel, QVBoxLayout, QHBoxLayout, QFrame
 
 from qfluentwidgets import (ScrollArea, PushButton, ToolButton, FluentIcon,
                             isDarkTheme, IconWidget, Theme, ToolTipFilter)

--- a/examples/gallery/app/view/home_interface.py
+++ b/examples/gallery/app/view/home_interface.py
@@ -1,9 +1,9 @@
 # coding:utf-8
 import json
 
-from PyQt5.QtCore import Qt, pyqtSignal, QRectF
-from PyQt5.QtGui import QPixmap, QPainter, QColor, QBrush, QPainterPath
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel
+from qtpy.QtCore import Qt, Signal, QRectF
+from qtpy.QtGui import QPixmap, QPainter, QColor, QBrush, QPainterPath
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QLabel
 
 from qfluentwidgets import ScrollArea, isDarkTheme, FluentIcon
 from ..common.config import cfg, HELP_URL, REPO_URL, EXAMPLE_URL, FEEDBACK_URL

--- a/examples/gallery/app/view/layout_interface.py
+++ b/examples/gallery/app/view/layout_interface.py
@@ -1,5 +1,5 @@
 # coding:utf-8
-from PyQt5.QtWidgets import QWidget
+from qtpy.QtWidgets import QWidget
 from qfluentwidgets import FlowLayout, PushButton
 
 from .gallery_interface import GalleryInterface

--- a/examples/gallery/app/view/main_window.py
+++ b/examples/gallery/app/view/main_window.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 from typing import List
-from PyQt5.QtCore import Qt, pyqtSignal, QEasingCurve
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QApplication, QHBoxLayout, QFrame, QWidget
+from qtpy.QtCore import Qt, Signal, QEasingCurve
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QApplication, QHBoxLayout, QFrame, QWidget
 
 from qfluentwidgets import (NavigationInterface, NavigationItemPostion, MessageBox,
                             isDarkTheme, PopUpAniStackedWidget)
@@ -29,7 +29,7 @@ from ..common.signal_bus import signalBus
 class StackedWidget(QFrame):
     """ Stacked widget """
 
-    currentWidgetChanged = pyqtSignal(QWidget)
+    currentWidgetChanged = Signal(QWidget)
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)

--- a/examples/gallery/app/view/material_interface.py
+++ b/examples/gallery/app/view/material_interface.py
@@ -1,5 +1,5 @@
 # coding:utf-8
-from PyQt5.QtGui import QColor
+from qtpy.QtGui import QColor
 from qfluentwidgets.components.widgets.acrylic_label import AcrylicLabel
 from qfluentwidgets import FluentIcon as FIF
 

--- a/examples/gallery/app/view/menu_interface.py
+++ b/examples/gallery/app/view/menu_interface.py
@@ -1,6 +1,6 @@
 # coding:utf-8
-from PyQt5.QtCore import QPoint
-from PyQt5.QtWidgets import QAction
+from qtpy.QtCore import QPoint
+from qtpy.QtWidgets import QAction
 from qfluentwidgets import RoundMenu, PushButton
 from qfluentwidgets import FluentIcon as FIF
 

--- a/examples/gallery/app/view/scroll_interface.py
+++ b/examples/gallery/app/view/scroll_interface.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import Qt, QEasingCurve
-from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import QWidget
+from qtpy.QtCore import Qt, QEasingCurve
+from qtpy.QtGui import QPixmap
+from qtpy.QtWidgets import QWidget
 from qfluentwidgets import ScrollArea, SmoothScrollArea, ToolTipFilter, PixmapLabel
 
 from .gallery_interface import GalleryInterface

--- a/examples/gallery/app/view/setting_interface.py
+++ b/examples/gallery/app/view/setting_interface.py
@@ -6,7 +6,7 @@ from qfluentwidgets import (SettingCardGroup, SwitchSettingCard, FolderListSetti
                             setTheme, setThemeColor, RangeSettingCard, isDarkTheme)
 from qfluentwidgets import FluentIcon as FIF
 from qfluentwidgets import InfoBar
-from PyQt5.QtCore import Qt, pyqtSignal, QUrl, QStandardPaths
+from PyQt5.QtCore import Qt, Signal, QUrl, QStandardPaths
 from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtWidgets import QWidget, QLabel, QFileDialog
 
@@ -17,11 +17,11 @@ from ..common.config import cfg, HELP_URL, FEEDBACK_URL, AUTHOR, VERSION, YEAR
 class SettingInterface(ScrollArea):
     """ Setting interface """
 
-    checkUpdateSig = pyqtSignal()
-    musicFoldersChanged = pyqtSignal(list)
-    acrylicEnableChanged = pyqtSignal(bool)
-    downloadFolderChanged = pyqtSignal(str)
-    minimizeToTrayChanged = pyqtSignal(bool)
+    checkUpdateSig = Signal()
+    musicFoldersChanged = Signal(list)
+    acrylicEnableChanged = Signal(bool)
+    downloadFolderChanged = Signal(str)
+    minimizeToTrayChanged = Signal(bool)
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)

--- a/examples/gallery/app/view/status_info_interface.py
+++ b/examples/gallery/app/view/status_info_interface.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QPixmap, QColor
-from PyQt5.QtWidgets import QWidget, QHBoxLayout
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QPixmap, QColor
+from qtpy.QtWidgets import QWidget, QHBoxLayout
 from qfluentwidgets import (StateToolTip, ToolTipFilter, PushButton, PixmapLabel,
                             InfoBar, InfoBarIcon, FluentIcon, InfoBarPosition)
 

--- a/examples/gallery/app/view/text_interface.py
+++ b/examples/gallery/app/view/text_interface.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QPixmap, QColor
-from PyQt5.QtWidgets import QWidget, QHBoxLayout
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QPixmap, QColor
+from qtpy.QtWidgets import QWidget, QHBoxLayout
 from qfluentwidgets import LineEdit, SpinBox, DoubleSpinBox, TimeEdit, DateTimeEdit, DateEdit, TextEdit
 
 from .gallery_interface import GalleryInterface

--- a/examples/gallery/app/view/title_bar.py
+++ b/examples/gallery/app/view/title_bar.py
@@ -1,7 +1,7 @@
 # coding: utf-8
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QLabel
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QLabel
 from qframelesswindow import TitleBar
 
 

--- a/examples/gallery/demo.py
+++ b/examples/gallery/demo.py
@@ -2,8 +2,8 @@
 import os
 import sys
 
-from PyQt5.QtCore import Qt, QLocale, QTranslator
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtCore import Qt, QLocale, QTranslator
+from qtpy.QtWidgets import QApplication
 
 from app.common.config import cfg, Language
 from app.view.main_window import MainWindow

--- a/examples/info_bar/demo.py
+++ b/examples/info_bar/demo.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget, QHBoxLayout
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget, QHBoxLayout
 
 from qfluentwidgets import InfoBarIcon, InfoBar, PushButton, setTheme, Theme, FluentIcon, InfoBarPosition
 

--- a/examples/line_edit/demo.py
+++ b/examples/line_edit/demo.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget
 
 from qfluentwidgets import LineEdit, PushButton, TextEdit
 

--- a/examples/menu/demo.py
+++ b/examples/menu/demo.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget, QAction, QHBoxLayout, QLabel
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget, QAction, QHBoxLayout, QLabel
 from qfluentwidgets import RoundMenu, setTheme, Theme
 from qfluentwidgets import FluentIcon as FIF
 

--- a/examples/message_dialog/demo.py
+++ b/examples/message_dialog/demo.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget
 
 from qfluentwidgets import MessageDialog, MessageBox, setTheme, Theme, PrimaryPushButton
 

--- a/examples/navigation/demo.py
+++ b/examples/navigation/demo.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt, QRect
-from PyQt5.QtGui import QIcon, QPainter, QImage, QBrush, QColor, QFont
-from PyQt5.QtWidgets import QApplication, QFrame, QStackedWidget, QHBoxLayout, QLabel
+from qtpy.QtCore import Qt, QRect
+from qtpy.QtGui import QIcon, QPainter, QImage, QBrush, QColor, QFont
+from qtpy.QtWidgets import QApplication, QFrame, QStackedWidget, QHBoxLayout, QLabel
 
 from qfluentwidgets import (NavigationInterface, NavigationItemPostion, NavigationWidget, MessageBox,
                             isDarkTheme, setTheme, Theme, setThemeColor)

--- a/examples/navigation2/demo.py
+++ b/examples/navigation2/demo.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt, QRect
-from PyQt5.QtGui import QIcon, QPainter, QImage, QBrush, QColor, QFont
-from PyQt5.QtWidgets import QApplication, QFrame, QStackedWidget, QHBoxLayout, QLabel
+from qtpy.QtCore import Qt, QRect
+from qtpy.QtGui import QIcon, QPainter, QImage, QBrush, QColor, QFont
+from qtpy.QtWidgets import QApplication, QFrame, QStackedWidget, QHBoxLayout, QLabel
 
 from qfluentwidgets import (NavigationInterface, NavigationItemPostion, NavigationWidget, MessageBox,
                             isDarkTheme, setTheme, Theme)

--- a/examples/navigation3/demo.py
+++ b/examples/navigation3/demo.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QApplication, QStackedWidget, QHBoxLayout, QLabel, QWidget, QVBoxLayout
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QApplication, QStackedWidget, QHBoxLayout, QLabel, QWidget, QVBoxLayout
 
 from qfluentwidgets import (NavigationInterface, NavigationItemPostion, NavigationWidget, MessageBox,
                             isDarkTheme, setTheme, Theme, setThemeColor, NavigationToolButton, NavigationPanel)

--- a/examples/radio_button/demo.py
+++ b/examples/radio_button/demo.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 import sys
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget, QVBoxLayout
 from qfluentwidgets import RadioButton
 
 

--- a/examples/scroll_area/demo.py
+++ b/examples/scroll_area/demo.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import QEasingCurve, Qt
-from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtCore import QEasingCurve, Qt
+from qtpy.QtGui import QPixmap
+from qtpy.QtWidgets import QApplication
 from qfluentwidgets import SmoothScrollArea, PixmapLabel
 
 

--- a/examples/settings/config.py
+++ b/examples/settings/config.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 from enum import Enum
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QGuiApplication, QFont
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QGuiApplication, QFont
 from qfluentwidgets import (qconfig, QConfig, ConfigItem, OptionsConfigItem, BoolValidator,
                             ColorConfigItem, OptionsValidator, RangeConfigItem, RangeValidator,
                             FolderListValidator, EnumSerializer, FolderValidator)

--- a/examples/settings/demo.py
+++ b/examples/settings/demo.py
@@ -2,9 +2,9 @@
 import os
 import sys
 
-from PyQt5.QtCore import Qt, QLocale, QTranslator
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QApplication, QHBoxLayout
+from qtpy.QtCore import Qt, QLocale, QTranslator
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QApplication, QHBoxLayout
 
 from qframelesswindow import FramelessWindow, StandardTitleBar
 from qfluentwidgets import isDarkTheme

--- a/examples/settings/setting_interface.py
+++ b/examples/settings/setting_interface.py
@@ -6,9 +6,9 @@ from qfluentwidgets import (SettingCardGroup, SwitchSettingCard, FolderListSetti
                             ComboBoxSettingCard, ExpandLayout, Theme, InfoBar, CustomColorSettingCard,
                             setTheme, setThemeColor, isDarkTheme)
 from qfluentwidgets import FluentIcon as FIF
-from PyQt5.QtCore import Qt, pyqtSignal, QUrl, QStandardPaths
-from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtWidgets import QWidget, QLabel, QFontDialog, QFileDialog
+from qtpy.QtCore import Qt, pyqtSignal, QUrl, QStandardPaths
+from qtpy.QtGui import QDesktopServices
+from qtpy.QtWidgets import QWidget, QLabel, QFontDialog, QFileDialog
 
 
 class SettingInterface(ScrollArea):

--- a/examples/slider/demo.py
+++ b/examples/slider/demo.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor
-from PyQt5.QtWidgets import QApplication, QWidget, QSlider
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QApplication, QWidget, QSlider
 
 from qfluentwidgets import HollowHandleStyle, Slider, setTheme, Theme
 

--- a/examples/spin_box/demo.py
+++ b/examples/spin_box/demo.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget, QVBoxLayout
 
 from qfluentwidgets import SpinBox, DoubleSpinBox, DateTimeEdit, DateEdit, TimeEdit
 

--- a/examples/state_tool_tip/demo.py
+++ b/examples/state_tool_tip/demo.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget
 
 from qfluentwidgets import StateToolTip, PushButton, setTheme, Theme
 

--- a/examples/switch_button/demo.py
+++ b/examples/switch_button/demo.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QWidget
 
 from qfluentwidgets import SwitchButton
 

--- a/examples/tool_tip/demo.py
+++ b/examples/tool_tip/demo.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 import sys
-from PyQt5.QtCore import QEvent, QPoint, Qt, QUrl
-from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtWidgets import QApplication, QWidget, QHBoxLayout
+from qtpy.QtCore import QEvent, QPoint, Qt, QUrl
+from qtpy.QtGui import QDesktopServices
+from qtpy.QtWidgets import QApplication, QWidget, QHBoxLayout
 
 from qfluentwidgets import ToolTip, ToolTipFilter, setTheme, Theme, PushButton
 

--- a/qfluentwidgets/_rc/resource.py
+++ b/qfluentwidgets/_rc/resource.py
@@ -6,7 +6,7 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt5 import QtCore
+from qtpy import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x05\x86\

--- a/qfluentwidgets/common/config.py
+++ b/qfluentwidgets/common/config.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from typing import List
 
 import darkdetect
-from PyQt5.QtCore import QObject, pyqtSignal
-from PyQt5.QtGui import QColor
+from qtpy.QtCore import QObject, Signal
+from qtpy.QtGui import QColor
 
 from .exception_handler import exceptionHandler
 
@@ -157,7 +157,7 @@ class ColorSerializer(ConfigSerializer):
 class ConfigItem(QObject):
     """ Config item """
 
-    valueChanged = pyqtSignal(object)
+    valueChanged = Signal(object)
 
     def __init__(self, group, name, default, validator=None, serializer=None, restart=False):
         """
@@ -256,9 +256,9 @@ class ColorConfigItem(ConfigItem):
 class QConfig(QObject):
     """ Config of app """
 
-    appRestartSig = pyqtSignal()
-    themeChanged = pyqtSignal(Theme)
-    themeColorChanged = pyqtSignal(QColor)
+    appRestartSig = Signal()
+    themeChanged = Signal(Theme)
+    themeColorChanged = Signal(QColor)
 
     themeMode = OptionsConfigItem(
         "QFluentWidgets", "ThemeMode", Theme.AUTO, OptionsValidator(Theme), EnumSerializer(Theme))

--- a/qfluentwidgets/common/icon.py
+++ b/qfluentwidgets/common/icon.py
@@ -1,10 +1,10 @@
 # coding:utf-8
 from enum import Enum
 
-from PyQt5.QtXml import QDomDocument
-from PyQt5.QtCore import QPoint, QRect, QRectF, Qt, QFile
-from PyQt5.QtGui import QIcon, QIconEngine, QImage, QPainter, QPixmap, QColor
-from PyQt5.QtSvg import QSvgRenderer
+from qtpy.QtXml import QDomDocument
+from qtpy.QtCore import QPoint, QRect, QRectF, Qt, QFile
+from qtpy.QtGui import QIcon, QIconEngine, QImage, QPainter, QPixmap, QColor
+from qtpy.QtSvg import QSvgRenderer
 
 from .config import isDarkTheme, Theme
 

--- a/qfluentwidgets/common/smooth_scroll.py
+++ b/qfluentwidgets/common/smooth_scroll.py
@@ -3,9 +3,9 @@ from collections import deque
 from enum import Enum
 from math import cos, pi
 
-from PyQt5.QtCore import QDateTime, Qt, QTimer, QPoint
-from PyQt5.QtGui import QWheelEvent
-from PyQt5.QtWidgets import QApplication, QScrollArea, QAbstractScrollArea
+from qtpy.QtCore import QDateTime, Qt, QTimer, QPoint
+from qtpy.QtGui import QWheelEvent
+from qtpy.QtWidgets import QApplication, QScrollArea, QAbstractScrollArea
 
 
 class SmoothScroll:

--- a/qfluentwidgets/common/style_sheet.py
+++ b/qfluentwidgets/common/style_sheet.py
@@ -3,9 +3,9 @@ from enum import Enum
 from string import Template
 import weakref
 
-from PyQt5.QtCore import QFile, QObject
-from PyQt5.QtGui import QColor
-from PyQt5.QtWidgets import QWidget
+from qtpy.QtCore import QFile, QObject
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QWidget
 
 from .config import qconfig, Theme, isDarkTheme
 
@@ -14,6 +14,7 @@ class StyleSheetManager(QObject):
     """ Style sheet manager """
 
     def __init__(self):
+        super().__init__()
         self.widgets = weakref.WeakKeyDictionary()
 
     def register(self, file: str, widget: QWidget):

--- a/qfluentwidgets/components/dialog_box/color_dialog.py
+++ b/qfluentwidgets/components/dialog_box/color_dialog.py
@@ -1,8 +1,8 @@
 # coding:utf-8
-from PyQt5.QtCore import Qt, pyqtSignal, QPoint, QRegExp, QSize
-from PyQt5.QtGui import (QBrush, QColor, QPixmap,
+from qtpy.QtCore import Qt, Signal, QPoint, QRegExp, QSize
+from qtpy.QtGui import (QBrush, QColor, QPixmap,
                          QPainter, QPen, QIntValidator, QRegExpValidator, QIcon)
-from PyQt5.QtWidgets import QApplication, QLabel, QWidget, QPushButton, QFrame, QVBoxLayout
+from qtpy.QtWidgets import QApplication, QLabel, QWidget, QPushButton, QFrame, QVBoxLayout
 
 from ...common.style_sheet import setStyleSheet, getStyleSheet
 from ..widgets import Slider, ScrollArea, PushButton, PrimaryPushButton
@@ -13,7 +13,7 @@ from .mask_dialog_base import MaskDialogBase
 class HuePanel(QWidget):
     """ Hue panel """
 
-    colorChanged = pyqtSignal(QColor)
+    colorChanged = Signal(QColor)
 
     def __init__(self, color=QColor(255, 0, 0), parent=None):
         super().__init__(parent=parent)
@@ -81,7 +81,7 @@ class HuePanel(QWidget):
 class BrightnessSlider(Slider):
     """ Brightness slider """
 
-    colorChanged = pyqtSignal(QColor)
+    colorChanged = Signal(QColor)
 
     def __init__(self, color, parent=None):
         super().__init__(Qt.Horizontal, parent)
@@ -131,7 +131,7 @@ class ColorCard(QWidget):
 class ColorLineEdit(LineEdit):
     """ Color line edit """
 
-    valueChanged = pyqtSignal(str)
+    valueChanged = Signal(str)
 
     def __init__(self, value, parent=None):
         super().__init__(str(value), parent)
@@ -167,7 +167,7 @@ class HexColorLineEdit(ColorLineEdit):
 class ColorDialog(MaskDialogBase):
     """ Color dialog """
 
-    colorChanged = pyqtSignal(QColor)
+    colorChanged = Signal(QColor)
 
     def __init__(self, color, title: str, parent=None):
         """

--- a/qfluentwidgets/components/dialog_box/dialog.py
+++ b/qfluentwidgets/components/dialog_box/dialog.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import Qt, pyqtSignal, QObject, QEvent
-from PyQt5.QtGui import QColor
-from PyQt5.QtWidgets import QLabel, QFrame, QVBoxLayout, QHBoxLayout, QPushButton
+from qtpy.QtCore import Qt, Signal, QObject, QEvent
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QLabel, QFrame, QVBoxLayout, QHBoxLayout, QPushButton
 from qframelesswindow import FramelessDialog
 
 from ...common.auto_wrap import TextWrap
@@ -14,8 +14,8 @@ from .mask_dialog_base import MaskDialogBase
 class Ui_MessageBox:
     """ Ui of message box """
 
-    yesSignal = pyqtSignal()
-    cancelSignal = pyqtSignal()
+    yesSignal = Signal()
+    cancelSignal = Signal()
 
     def _setUpUi(self, title, content, parent):
         self.content = content
@@ -102,8 +102,8 @@ class Ui_MessageBox:
 class Dialog(FramelessDialog, Ui_MessageBox):
     """ Dialog box """
 
-    yesSignal = pyqtSignal()
-    cancelSignal = pyqtSignal()
+    yesSignal = Signal()
+    cancelSignal = Signal()
 
     def __init__(self, title: str, content: str, parent=None):
         super().__init__(parent=parent)
@@ -124,8 +124,8 @@ class Dialog(FramelessDialog, Ui_MessageBox):
 class MessageBox(MaskDialogBase, Ui_MessageBox):
     """ Message box """
 
-    yesSignal = pyqtSignal()
-    cancelSignal = pyqtSignal()
+    yesSignal = Signal()
+    cancelSignal = Signal()
 
     def __init__(self, title: str, content: str, parent=None):
         super().__init__(parent=parent)

--- a/qfluentwidgets/components/dialog_box/folder_list_dialog.py
+++ b/qfluentwidgets/components/dialog_box/folder_list_dialog.py
@@ -1,10 +1,10 @@
 # coding:utf-8
 import os
 
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import (QBrush, QColor, QFont, QFontMetrics, QMouseEvent,
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import (QBrush, QColor, QFont, QFontMetrics, QMouseEvent,
                          QPainter, QPen, QPixmap)
-from PyQt5.QtWidgets import (QApplication, QFileDialog, QHBoxLayout, QLabel,
+from qtpy.QtWidgets import (QApplication, QFileDialog, QHBoxLayout, QLabel,
                              QVBoxLayout, QWidget, QPushButton)
 
 from ...common.config import isDarkTheme
@@ -18,7 +18,7 @@ from ..widgets.scroll_area import ScrollArea
 class FolderListDialog(MaskDialogBase):
     """ Folder list dialog box """
 
-    folderChanged = pyqtSignal(list)
+    folderChanged = Signal(list)
 
     def __init__(self, folderPaths: list, title: str, content: str, parent):
         super().__init__(parent=parent)
@@ -175,7 +175,7 @@ class FolderListDialog(MaskDialogBase):
 class ClickableWindow(QWidget):
     """ Clickable window """
 
-    clicked = pyqtSignal()
+    clicked = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/qfluentwidgets/components/dialog_box/mask_dialog_base.py
+++ b/qfluentwidgets/components/dialog_box/mask_dialog_base.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import QEasingCurve, QPropertyAnimation, Qt, QEvent
-from PyQt5.QtGui import QColor, QResizeEvent
-from PyQt5.QtWidgets import (QDialog, QGraphicsDropShadowEffect,
+from qtpy.QtCore import QEasingCurve, QPropertyAnimation, Qt, QEvent
+from qtpy.QtGui import QColor, QResizeEvent
+from qtpy.QtWidgets import (QDialog, QGraphicsDropShadowEffect,
                              QGraphicsOpacityEffect, QHBoxLayout, QWidget, QFrame)
 
 from ...common.config import isDarkTheme

--- a/qfluentwidgets/components/dialog_box/message_dialog.py
+++ b/qfluentwidgets/components/dialog_box/message_dialog.py
@@ -1,6 +1,6 @@
 # coding:utf-8
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QLabel, QPushButton
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QLabel, QPushButton
 
 from ...common.auto_wrap import TextWrap
 from ...common.style_sheet import setStyleSheet
@@ -10,8 +10,8 @@ from .mask_dialog_base import MaskDialogBase
 class MessageDialog(MaskDialogBase):
     """ Win10 style message dialog box with a mask """
 
-    yesSignal = pyqtSignal()
-    cancelSignal = pyqtSignal()
+    yesSignal = Signal()
+    cancelSignal = Signal()
 
     def __init__(self, title: str, content: str, parent):
         super().__init__(parent=parent)

--- a/qfluentwidgets/components/layout/expand_layout.py
+++ b/qfluentwidgets/components/layout/expand_layout.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import QSize, QPoint, Qt, QEvent, QRect
-from PyQt5.QtGui import QResizeEvent
-from PyQt5.QtWidgets import QLayout, QWidget
+from qtpy.QtCore import QSize, QPoint, Qt, QEvent, QRect
+from qtpy.QtGui import QResizeEvent
+from qtpy.QtWidgets import QLayout, QWidget
 
 
 class ExpandLayout(QLayout):

--- a/qfluentwidgets/components/layout/flow_layout.py
+++ b/qfluentwidgets/components/layout/flow_layout.py
@@ -1,6 +1,6 @@
 # coding:utf-8
-from PyQt5.QtCore import QSize, QPoint, Qt, QRect, QPropertyAnimation, QParallelAnimationGroup, QEasingCurve
-from PyQt5.QtWidgets import QLayout, QWidgetItem
+from qtpy.QtCore import QSize, QPoint, Qt, QRect, QPropertyAnimation, QParallelAnimationGroup, QEasingCurve
+from qtpy.QtWidgets import QLayout, QWidgetItem
 
 
 class FlowLayout(QLayout):

--- a/qfluentwidgets/components/layout/v_box_layout.py
+++ b/qfluentwidgets/components/layout/v_box_layout.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 from typing import List
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QVBoxLayout, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QVBoxLayout, QWidget
 
 
 class VBoxLayout(QVBoxLayout):

--- a/qfluentwidgets/components/navigation/navigation_interface.py
+++ b/qfluentwidgets/components/navigation/navigation_interface.py
@@ -1,9 +1,9 @@
 # coding:utf-8
 from typing import Union
 
-from PyQt5.QtCore import Qt, QEvent, pyqtSignal
-from PyQt5.QtGui import QResizeEvent, QIcon
-from PyQt5.QtWidgets import QWidget
+from qtpy.QtCore import Qt, QEvent, Signal
+from qtpy.QtGui import QResizeEvent, QIcon
+from qtpy.QtWidgets import QWidget
 
 from .navigation_panel import NavigationPanel, NavigationItemPostion, NavigationWidget, NavigationDisplayMode
 from ...common.style_sheet import setStyleSheet
@@ -13,7 +13,7 @@ from ...common.icon import FluentIconBase
 class NavigationInterface(QWidget):
     """ Navigation interface """
 
-    displayModeChanged = pyqtSignal(NavigationDisplayMode)
+    displayModeChanged = Signal(NavigationDisplayMode)
 
     def __init__(self, parent=None, showMenuButton=True, showReturnButton=False):
         """

--- a/qfluentwidgets/components/navigation/navigation_panel.py
+++ b/qfluentwidgets/components/navigation/navigation_panel.py
@@ -2,9 +2,9 @@
 from enum import Enum
 from typing import Dict, Union
 
-from PyQt5.QtCore import Qt, QPropertyAnimation, QRect, QSize, QEvent, QEasingCurve, pyqtSignal, QObject
-from PyQt5.QtGui import QResizeEvent, QIcon
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QFrame, QApplication
+from qtpy.QtCore import Qt, QPropertyAnimation, QRect, QSize, QEvent, QEasingCurve, Signal, QObject
+from qtpy.QtGui import QResizeEvent, QIcon
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QFrame, QApplication
 
 from .navigation_widget import NavigationPushButton, NavigationToolButton, NavigationWidget, NavigationSeparator
 from ..widgets.scroll_area import ScrollArea
@@ -31,7 +31,7 @@ class NavigationItemPostion(Enum):
 class NavigationPanel(QFrame):
     """ Navigation panel """
 
-    displayModeChanged = pyqtSignal(NavigationDisplayMode)
+    displayModeChanged = Signal(NavigationDisplayMode)
 
     def __init__(self, parent=None, isMinimalEnabled=False):
         super().__init__(parent=parent)
@@ -365,7 +365,7 @@ class NavigationItemLayout(QVBoxLayout):
 class NavigationHistory(QObject):
     """ Navigation history """
 
-    emptyChanged = pyqtSignal(bool)
+    emptyChanged = Signal(bool)
 
     def __init__(self, items: Dict[str, NavigationWidget]):
         super().__init__()

--- a/qfluentwidgets/components/navigation/navigation_widget.py
+++ b/qfluentwidgets/components/navigation/navigation_widget.py
@@ -1,9 +1,9 @@
 # coding:utf-8
 from typing import Union
 
-from PyQt5.QtCore import Qt, pyqtSignal, QRect, QRectF
-from PyQt5.QtGui import QColor, QPainter, QPen, QIcon
-from PyQt5.QtWidgets import QWidget
+from qtpy.QtCore import Qt, Signal, QRect, QRectF
+from qtpy.QtGui import QColor, QPainter, QPen, QIcon
+from qtpy.QtWidgets import QWidget
 
 from ...common.config import isDarkTheme
 from ...common.style_sheet import themeColor
@@ -14,7 +14,7 @@ from ...common.icon import FluentIcon as FIF
 class NavigationWidget(QWidget):
     """ Navigation widget """
 
-    clicked = pyqtSignal(bool)  # whether triggered by the user
+    clicked = Signal(bool)  # whether triggered by the user
     EXPAND_WIDTH = 312
 
     def __init__(self, isSelectable: bool, parent=None):

--- a/qfluentwidgets/components/settings/custom_color_setting_card.py
+++ b/qfluentwidgets/components/settings/custom_color_setting_card.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 from typing import Union
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QIcon, QColor
-from PyQt5.QtWidgets import QWidget, QLabel, QButtonGroup, QVBoxLayout, QPushButton, QHBoxLayout
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QIcon, QColor
+from qtpy.QtWidgets import QWidget, QLabel, QButtonGroup, QVBoxLayout, QPushButton, QHBoxLayout
 
 from ..dialog_box import ColorDialog
 from .expand_setting_card import ExpandGroupSettingCard
@@ -14,7 +14,7 @@ from ...common.icon import FluentIconBase
 class CustomColorSettingCard(ExpandGroupSettingCard):
     """ Custom color setting card """
 
-    colorChanged = pyqtSignal(QColor)
+    colorChanged = Signal(QColor)
 
     def __init__(self, configItem: ColorConfigItem, icon: Union[str, QIcon, FluentIconBase], title: str,
                  content=None, parent=None):

--- a/qfluentwidgets/components/settings/expand_setting_card.py
+++ b/qfluentwidgets/components/settings/expand_setting_card.py
@@ -1,10 +1,10 @@
 # coding:utf-8
 from typing import Union
-from PyQt5.QtGui import QIcon
-from PyQt5.QtCore import (QEvent, Qt, QPropertyAnimation, pyqtProperty, QEasingCurve,
+from qtpy.QtGui import QIcon
+from qtpy.QtCore import (QEvent, Qt, QPropertyAnimation, QEasingCurve,
                           QParallelAnimationGroup, QRect, QSize, QPoint, QRectF)
-from PyQt5.QtGui import QColor, QPainter
-from PyQt5.QtWidgets import QFrame, QWidget, QAbstractButton, QApplication
+from qtpy.QtGui import QColor, QPainter
+from qtpy.QtWidgets import QFrame, QWidget, QAbstractButton, QApplication
 
 from ...common.config import isDarkTheme
 from ...common.icon import FluentIcon as FIF
@@ -82,7 +82,7 @@ class ExpandButton(QAbstractButton):
         self.__angle = angle
         self.update()
 
-    angle = pyqtProperty(float, getAngle, setAngle)
+    angle = property(float, getAngle, setAngle)
 
 
 class ExpandSettingCard(QFrame):

--- a/qfluentwidgets/components/settings/folder_list_setting_card.py
+++ b/qfluentwidgets/components/settings/folder_list_setting_card.py
@@ -2,9 +2,9 @@
 from typing import List
 from pathlib import Path
 
-from PyQt5.QtCore import Qt, pyqtSignal, QRectF
-from PyQt5.QtGui import QPainter, QIcon
-from PyQt5.QtWidgets import (QPushButton, QFileDialog, QWidget, QLabel,
+from qtpy.QtCore import Qt, Signal, QRectF
+from qtpy.QtGui import QPainter, QIcon
+from qtpy.QtWidgets import (QPushButton, QFileDialog, QWidget, QLabel,
                              QHBoxLayout, QToolButton)
 
 from ...common.config import ConfigItem, qconfig
@@ -71,7 +71,7 @@ class PushButton(QPushButton):
 class FolderItem(QWidget):
     """ Folder item """
 
-    removed = pyqtSignal(QWidget)
+    removed = Signal(QWidget)
 
     def __init__(self, folder: str, parent=None):
         super().__init__(parent=parent)
@@ -95,7 +95,7 @@ class FolderItem(QWidget):
 class FolderListSettingCard(ExpandSettingCard):
     """ Folder list setting card """
 
-    folderChanged = pyqtSignal(list)
+    folderChanged = Signal(list)
 
     def __init__(self, configItem: ConfigItem, title: str, content: str = None, directory="./", parent=None):
         """

--- a/qfluentwidgets/components/settings/options_setting_card.py
+++ b/qfluentwidgets/components/settings/options_setting_card.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 from typing import Union
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QButtonGroup, QLabel
+from qtpy.QtCore import Signal
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QButtonGroup, QLabel
 
 from ...common.config import OptionsConfigItem, qconfig
 from ...common.icon import FluentIconBase
@@ -13,7 +13,7 @@ from .expand_setting_card import ExpandSettingCard
 class OptionsSettingCard(ExpandSettingCard):
     """ setting card with a group of options """
 
-    optionChanged = pyqtSignal(OptionsConfigItem)
+    optionChanged = Signal(OptionsConfigItem)
 
     def __init__(self, configItem, icon: Union[str, QIcon, FluentIconBase], title, content=None, texts=None, parent=None):
         """

--- a/qfluentwidgets/components/settings/setting_card.py
+++ b/qfluentwidgets/components/settings/setting_card.py
@@ -1,9 +1,9 @@
 # coding:utf-8
 from typing import Union
 
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QColor, QIcon, QPainter
-from PyQt5.QtWidgets import (QFrame, QHBoxLayout, QLabel, QToolButton,
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QColor, QIcon, QPainter
+from qtpy.QtWidgets import (QFrame, QHBoxLayout, QLabel, QToolButton,
                              QVBoxLayout, QPushButton)
 
 from ..dialog_box.color_dialog import ColorDialog
@@ -87,7 +87,7 @@ class SettingCard(QFrame):
 class SwitchSettingCard(SettingCard):
     """ Setting card with switch button """
 
-    checkedChanged = pyqtSignal(bool)
+    checkedChanged = Signal(bool)
 
     def __init__(self, icon: Union[str, QIcon, FluentIconBase], title, content=None,
                  configItem: ConfigItem = None, parent=None):
@@ -144,7 +144,7 @@ class SwitchSettingCard(SettingCard):
 class RangeSettingCard(SettingCard):
     """ Setting card with a slider """
 
-    valueChanged = pyqtSignal(int)
+    valueChanged = Signal(int)
 
     def __init__(self, configItem, icon: Union[str, QIcon, FluentIconBase], title, content=None, parent=None):
         """
@@ -200,7 +200,7 @@ class RangeSettingCard(SettingCard):
 class PushSettingCard(SettingCard):
     """ Setting card with a push button """
 
-    clicked = pyqtSignal()
+    clicked = Signal()
 
     def __init__(self, text, icon: Union[str, QIcon, FluentIconBase], title, content=None, parent=None):
         """
@@ -273,7 +273,7 @@ class HyperlinkCard(SettingCard):
 class ColorPickerButton(QToolButton):
     """ Color picker button """
 
-    colorChanged = pyqtSignal(QColor)
+    colorChanged = Signal(QColor)
 
     def __init__(self, color: QColor, title: str, parent=None):
         super().__init__(parent=parent)
@@ -315,7 +315,7 @@ class ColorPickerButton(QToolButton):
 class ColorSettingCard(SettingCard):
     """ Setting card with color picker """
 
-    colorChanged = pyqtSignal(QColor)
+    colorChanged = Signal(QColor)
 
     def __init__(self, configItem, icon: Union[str, QIcon, FluentIconBase], title, content=None, parent=None):
         """

--- a/qfluentwidgets/components/settings/setting_card_group.py
+++ b/qfluentwidgets/components/settings/setting_card_group.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 from typing import List
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QWidget, QLabel, QVBoxLayout
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QWidget, QLabel, QVBoxLayout
 
 from ...common.style_sheet import setStyleSheet
 from ..layout.expand_layout import ExpandLayout

--- a/qfluentwidgets/components/widgets/acrylic_label.py
+++ b/qfluentwidgets/components/widgets/acrylic_label.py
@@ -1,9 +1,9 @@
 # coding:utf-8
 import warnings
 
-from PyQt5.QtCore import Qt, QThread, pyqtSignal
-from PyQt5.QtGui import QBrush, QColor, QImage, QPainter, QPixmap
-from PyQt5.QtWidgets import QLabel
+from qtpy.QtCore import Qt, QThread, Signal
+from qtpy.QtGui import QBrush, QColor, QImage, QPainter, QPixmap
+from qtpy.QtWidgets import QLabel
 
 try:
     from ...common.image_utils import gaussianBlur
@@ -18,7 +18,7 @@ except ImportError as e:
 class BlurCoverThread(QThread):
     """ Blur album cover thread """
 
-    blurFinished = pyqtSignal(QPixmap)
+    blurFinished = Signal(QPixmap)
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/qfluentwidgets/components/widgets/button.py
+++ b/qfluentwidgets/components/widgets/button.py
@@ -1,9 +1,9 @@
 # coding:utf-8
 from typing import Union
 
-from PyQt5.QtCore import QUrl, Qt, QRectF, QSize
-from PyQt5.QtGui import QDesktopServices, QIcon, QPainter
-from PyQt5.QtWidgets import QPushButton, QRadioButton, QToolButton, QAbstractButton
+from qtpy.QtCore import QUrl, Qt, QRectF, QSize
+from qtpy.QtGui import QDesktopServices, QIcon, QPainter
+from qtpy.QtWidgets import QPushButton, QRadioButton, QToolButton, QAbstractButton
 
 from ...common.icon import FluentIconBase, drawIcon, isDarkTheme, Theme
 from ...common.style_sheet import setStyleSheet

--- a/qfluentwidgets/components/widgets/check_box.py
+++ b/qfluentwidgets/components/widgets/check_box.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from PyQt5.QtWidgets import QCheckBox
+from qtpy.QtWidgets import QCheckBox
 
 from ...common.style_sheet import setStyleSheet
 

--- a/qfluentwidgets/components/widgets/combo_box.py
+++ b/qfluentwidgets/components/widgets/combo_box.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import Qt, pyqtSignal, QRect, QRectF, QPoint
-from PyQt5.QtGui import QColor, QPainter, QCursor
-from PyQt5.QtWidgets import QAction, QPushButton, QWidget
+from qtpy.QtCore import Qt, Signal, QRect, QRectF, QPoint
+from qtpy.QtGui import QColor, QPainter, QCursor
+from qtpy.QtWidgets import QAction, QPushButton, QWidget
 
 from .menu import RoundMenu
 from ...common.config import isDarkTheme
@@ -12,8 +12,8 @@ from ...common.style_sheet import setStyleSheet, themeColor
 class ComboBox(QPushButton):
     """ Combo box """
 
-    currentIndexChanged = pyqtSignal(int)
-    currentTextChanged = pyqtSignal(str)
+    currentIndexChanged = Signal(int)
+    currentTextChanged = Signal(str)
 
     def __init__(self, parent=None):
         super().__init__("", parent)

--- a/qfluentwidgets/components/widgets/icon_widget.py
+++ b/qfluentwidgets/components/widgets/icon_widget.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 from typing import Union
 
-from PyQt5.QtGui import QIcon, QPainter
-from PyQt5.QtWidgets import QWidget
+from qtpy.QtGui import QIcon, QPainter
+from qtpy.QtWidgets import QWidget
 
 from ...common.icon import FluentIconBase, drawIcon
 

--- a/qfluentwidgets/components/widgets/info_bar.py
+++ b/qfluentwidgets/components/widgets/info_bar.py
@@ -3,10 +3,10 @@ from enum import Enum
 from typing import Union
 import weakref
 
-from PyQt5.QtCore import (Qt, QEvent, QSize, QRectF, QObject, QPropertyAnimation,
-                          QEasingCurve, QTimer, pyqtSignal, QParallelAnimationGroup, QPoint)
-from PyQt5.QtGui import QPainter, QIcon, QColor
-from PyQt5.QtWidgets import (QWidget, QFrame, QLabel, QHBoxLayout, QVBoxLayout,
+from qtpy.QtCore import (Qt, QEvent, QSize, QRectF, QObject, QPropertyAnimation,
+                          QEasingCurve, QTimer, Signal, QParallelAnimationGroup, QPoint)
+from qtpy.QtGui import QPainter, QIcon, QColor
+from qtpy.QtWidgets import (QWidget, QFrame, QLabel, QHBoxLayout, QVBoxLayout,
                              QToolButton, QGraphicsOpacityEffect)
 
 from ...common.auto_wrap import TextWrap
@@ -85,7 +85,7 @@ class InfoIconWidget(QWidget):
 class InfoBar(QFrame):
     """ Information bar """
 
-    closedSignal = pyqtSignal()
+    closedSignal = Signal()
 
     def __init__(self, icon: Union[InfoBarIcon, FluentIconBase, QIcon, str], title: str, content: str,
                  orient=Qt.Horizontal, isClosable=True, duration=1000, position=InfoBarPosition.TOP_RIGHT,

--- a/qfluentwidgets/components/widgets/label.py
+++ b/qfluentwidgets/components/widgets/label.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QPixmap, QPainter
-from PyQt5.QtWidgets import QLabel
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QPixmap, QPainter
+from qtpy.QtWidgets import QLabel
 
 
 class PixmapLabel(QLabel):

--- a/qfluentwidgets/components/widgets/line_edit.py
+++ b/qfluentwidgets/components/widgets/line_edit.py
@@ -1,7 +1,7 @@
 # coding: utf-8
-from PyQt5.QtCore import QSize, Qt, QRectF, QEvent
-from PyQt5.QtGui import QPainter, QPainterPath
-from PyQt5.QtWidgets import QLineEdit, QToolButton, QTextEdit, QPlainTextEdit
+from qtpy.QtCore import QSize, Qt, QRectF, QEvent
+from qtpy.QtGui import QPainter, QPainterPath
+from qtpy.QtWidgets import QLineEdit, QToolButton, QTextEdit, QPlainTextEdit
 
 from ...common.style_sheet import setStyleSheet, themeColor
 from ...common.icon import writeSvg, isDarkTheme, drawSvgIcon

--- a/qfluentwidgets/components/widgets/menu.py
+++ b/qfluentwidgets/components/widgets/menu.py
@@ -1,9 +1,9 @@
 # coding:utf-8
 from qframelesswindow import WindowEffect
-from PyQt5.QtCore import (QEasingCurve, QEvent, QPropertyAnimation, QRect,
-                          Qt, QSize, QRectF, pyqtSignal, QPoint, QTimer)
-from PyQt5.QtGui import QIcon, QColor, QPainter, QPen, QPixmap, QRegion, QCursor, QTextCursor
-from PyQt5.QtWidgets import (QAction, QApplication, QMenu, QProxyStyle, QStyle,
+from qtpy.QtCore import (QEasingCurve, QEvent, QPropertyAnimation, QRect,
+                          Qt, QSize, QRectF, Signal, QPoint, QTimer)
+from qtpy.QtGui import QIcon, QColor, QPainter, QPen, QPixmap, QRegion, QCursor, QTextCursor
+from qtpy.QtWidgets import (QAction, QApplication, QMenu, QProxyStyle, QStyle,
                              QGraphicsDropShadowEffect, QListWidget, QWidget, QHBoxLayout,
                              QListWidgetItem, QLineEdit, QTextEdit)
 
@@ -71,7 +71,7 @@ class MenuSeparator(QWidget):
 class SubMenuItemWidget(QWidget):
     """ Sub menu item """
 
-    showMenuSig = pyqtSignal(QListWidgetItem)
+    showMenuSig = Signal(QListWidgetItem)
 
     def __init__(self, menu, item, parent=None):
         """
@@ -173,7 +173,7 @@ class MenuActionListWidget(QListWidget):
 class RoundMenu(QWidget):
     """ Round corner menu """
 
-    closedSignal = pyqtSignal()
+    closedSignal = Signal()
 
     def __init__(self, title="", parent=None):
         super().__init__(parent=parent)

--- a/qfluentwidgets/components/widgets/scroll_area.py
+++ b/qfluentwidgets/components/widgets/scroll_area.py
@@ -1,6 +1,6 @@
 # coding:utf-8
-from PyQt5.QtCore import QEasingCurve, Qt, pyqtSignal, QPropertyAnimation
-from PyQt5.QtWidgets import QScrollArea, QScrollBar
+from qtpy.QtCore import QEasingCurve, Qt, Signal, QPropertyAnimation
+from qtpy.QtWidgets import QScrollArea, QScrollBar
 
 from ...common.smooth_scroll import SmoothScroll, SmoothMode
 
@@ -38,7 +38,7 @@ class ScrollArea(QScrollArea):
 class SmoothScrollBar(QScrollBar):
     """ Smooth scroll bar """
 
-    scrollFinished = pyqtSignal()
+    scrollFinished = Signal()
 
     def __init__(self, parent=None):
         QScrollBar.__init__(self, parent)

--- a/qfluentwidgets/components/widgets/slider.py
+++ b/qfluentwidgets/components/widgets/slider.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import QSize, Qt, pyqtSignal, QPoint, QRectF
-from PyQt5.QtGui import QColor, QMouseEvent, QPainter, QPainterPath
-from PyQt5.QtWidgets import (QProxyStyle, QSlider, QStyle, QStyleOptionSlider,
+from qtpy.QtCore import QSize, Qt, Signal, QPoint, QRectF
+from qtpy.QtGui import QColor, QMouseEvent, QPainter, QPainterPath
+from qtpy.QtWidgets import (QProxyStyle, QSlider, QStyle, QStyleOptionSlider,
                              QWidget)
 
 from ...common.style_sheet import setStyleSheet
@@ -10,7 +10,7 @@ from ...common.style_sheet import setStyleSheet
 class Slider(QSlider):
     """ A slider can be clicked """
 
-    clicked = pyqtSignal(int)
+    clicked = Signal(int)
 
     def __init__(self, orientation, parent=None):
         super().__init__(orientation, parent=parent)

--- a/qfluentwidgets/components/widgets/spin_box.py
+++ b/qfluentwidgets/components/widgets/spin_box.py
@@ -1,9 +1,9 @@
 # coding:utf-8
 from enum import Enum
 
-from PyQt5.QtCore import Qt, QSize, QRectF
-from PyQt5.QtGui import QPainter, QPainterPath
-from PyQt5.QtWidgets import (QSpinBox, QDoubleSpinBox, QToolButton, QHBoxLayout,
+from qtpy.QtCore import Qt, QSize, QRectF
+from qtpy.QtGui import QPainter, QPainterPath
+from qtpy.QtWidgets import (QSpinBox, QDoubleSpinBox, QToolButton, QHBoxLayout,
                              QDateEdit, QDateTimeEdit, QTimeEdit, QLineEdit, QAbstractSpinBox)
 
 from ...common.style_sheet import setStyleSheet, themeColor

--- a/qfluentwidgets/components/widgets/stacked_widget.py
+++ b/qfluentwidgets/components/widgets/stacked_widget.py
@@ -2,10 +2,10 @@
 from typing import List
 from dataclasses import dataclass
 
-from PyQt5.QtCore import (QAbstractAnimation, QEasingCurve,
+from qtpy.QtCore import (QAbstractAnimation, QEasingCurve,
                           QParallelAnimationGroup, QPoint, QPropertyAnimation,
-                          pyqtSignal)
-from PyQt5.QtWidgets import QGraphicsOpacityEffect, QStackedWidget, QWidget
+                          Signal)
+from qtpy.QtWidgets import QGraphicsOpacityEffect, QStackedWidget, QWidget
 
 
 class OpacityAniStackedWidget(QStackedWidget):
@@ -67,8 +67,8 @@ class PopUpAniInfo:
 class PopUpAniStackedWidget(QStackedWidget):
     """ Stacked widget with pop up animation """
 
-    aniFinished = pyqtSignal()
-    aniStart = pyqtSignal()
+    aniFinished = Signal()
+    aniStart = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/qfluentwidgets/components/widgets/state_tool_tip.py
+++ b/qfluentwidgets/components/widgets/state_tool_tip.py
@@ -1,8 +1,8 @@
 # coding:utf-8
-from PyQt5.QtCore import QEasingCurve, QPropertyAnimation, Qt, QTimer, pyqtSignal, QSize, QPoint, QRectF
-from PyQt5.QtGui import QPainter
-from PyQt5.QtWidgets import QLabel, QWidget, QToolButton, QGraphicsOpacityEffect
-from PyQt5.QtSvg import QSvgWidget
+from qtpy.QtCore import QEasingCurve, QPropertyAnimation, Qt, QTimer, Signal, QSize, QPoint, QRectF
+from qtpy.QtGui import QPainter
+from qtpy.QtWidgets import QLabel, QWidget, QToolButton, QGraphicsOpacityEffect
+from qtpy.QtSvg import QSvgWidget
 
 from ...common import setStyleSheet, drawSvgIcon, isDarkTheme, Theme
 from ...common.icon import FluentIcon as FIF
@@ -50,7 +50,7 @@ class StateCloseButton(QToolButton):
 class StateToolTip(QWidget):
     """ State tooltip """
 
-    closedSignal = pyqtSignal()
+    closedSignal = Signal()
 
     def __init__(self, title, content, parent=None):
         """

--- a/qfluentwidgets/components/widgets/switch_button.py
+++ b/qfluentwidgets/components/widgets/switch_button.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 from enum import Enum
 
-from PyQt5.QtCore import Qt, QTimer, pyqtProperty, pyqtSignal
-from PyQt5.QtGui import QColor, QPainter
-from PyQt5.QtWidgets import QHBoxLayout, QLabel, QToolButton, QWidget
+from qtpy.QtCore import Qt, QTimer, Signal
+from qtpy.QtGui import QColor, QPainter
+from qtpy.QtWidgets import QHBoxLayout, QLabel, QToolButton, QWidget
 
 from ...common.style_sheet import setStyleSheet
 
@@ -11,7 +11,7 @@ from ...common.style_sheet import setStyleSheet
 class Indicator(QToolButton):
     """ Indicator of switch button """
 
-    checkedChanged = pyqtSignal(bool)
+    checkedChanged = Signal(bool)
 
     def __init__(self, parent):
         super().__init__(parent=parent)
@@ -112,9 +112,9 @@ class Indicator(QToolButton):
         self.__sliderDisabledColor = color
         self.update()
 
-    sliderOnColor = pyqtProperty(QColor, getSliderOnColor, setSliderOnColor)
-    sliderOffColor = pyqtProperty(QColor, getSliderOffColor, setSliderOffColor)
-    sliderDisabledColor = pyqtProperty(
+    sliderOnColor = property(QColor, getSliderOnColor, setSliderOnColor)
+    sliderOffColor = property(QColor, getSliderOffColor, setSliderOffColor)
+    sliderDisabledColor = property(
         QColor, getSliderDisabledColor, setSliderDisabledColor)
 
 
@@ -127,7 +127,7 @@ class IndicatorPosition(Enum):
 class SwitchButton(QWidget):
     """ Switch button class """
 
-    checkedChanged = pyqtSignal(bool)
+    checkedChanged = Signal(bool)
 
     def __init__(self, text='Off', parent=None, indicatorPos=IndicatorPosition.LEFT):
         """
@@ -199,4 +199,4 @@ class SwitchButton(QWidget):
         self.hBox.setSpacing(spacing)
         self.update()
 
-    spacing = pyqtProperty(int, getSpacing, setSpacing)
+    spacing = property(int, getSpacing, setSpacing)

--- a/qfluentwidgets/components/widgets/three_state_button.py
+++ b/qfluentwidgets/components/widgets/three_state_button.py
@@ -1,9 +1,9 @@
 # coding:utf-8
 from enum import Enum
 
-from PyQt5.QtCore import QEvent, QSize, Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QToolButton
+from qtpy.QtCore import QEvent, QSize, Qt
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QToolButton
 
 
 class ButtonState(Enum):

--- a/qfluentwidgets/components/widgets/tool_tip.py
+++ b/qfluentwidgets/components/widgets/tool_tip.py
@@ -1,7 +1,7 @@
 # coding:utf-8
-from PyQt5.QtCore import QEvent, QObject, QPoint, QTimer, Qt
-from PyQt5.QtGui import QColor, QCursor
-from PyQt5.QtWidgets import (QApplication, QFrame, QGraphicsDropShadowEffect,
+from qtpy.QtCore import QEvent, QObject, QPoint, QTimer, Qt
+from qtpy.QtGui import QColor, QCursor
+from qtpy.QtWidgets import (QApplication, QFrame, QGraphicsDropShadowEffect,
                              QHBoxLayout, QLabel, QWidget)
 
 from ...common import setStyleSheet

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ PyQt5>=5.15.0
 PyQt5-Frameless-Window
 darkdetect
 colorthief
-scipy
+scikit-image
 pillow
 sphinx-markdown-tables==0.0.17
 sphinx-intl
@@ -10,3 +10,4 @@ furo
 sphinx-autoapi
 sphinx-copybutton
 sphinx_design
+QtPy


### PR DESCRIPTION
1. scipy第三方库过于重量级（约130MB），换成轻量级的scikit-image （约40MB）。
2. 使用qtpy进行PyQt和PySide的适配，用property和Signal取代pyqtProperty和pyqtSignal。