### PR TITLE
fix: #41

### DIFF
--- a/qfluentwidgets/components/widgets/menu.py
+++ b/qfluentwidgets/components/widgets/menu.py
@@ -425,8 +425,12 @@ class RoundMenu(QWidget):
     def _onShowMenuTimeOut(self):
         if self.lastHoverSubMenuItem is None or not self.lastHoverItem is self.lastHoverSubMenuItem:
             return
-
+        
         w = self.view.itemWidget(self.lastHoverSubMenuItem)
+
+        if w.menu.parentMenu.isHidden():
+            return
+        
         pos = w.mapToGlobal(QPoint(w.width()+5, -5))
         w.menu.exec(pos)
 


### PR DESCRIPTION
fix: #41 
启动子菜单前使用了'QTimer'延迟了400ms，如果在这400ms内关闭父菜单的话，子菜单会正常启动，导致显示异常。这里多加了一个if条件判断父菜单是否已隐藏，如果已经隐藏的话则不启动子菜单。
PS: 现在的RoundMenu结构似乎并没有设计好？感觉子组件没有办法自动随父组件隐藏而隐藏。