### PR TITLE
修复combobox中setItemText方法出错

### DIFF
--- a/qfluentwidgets/components/widgets/combo_box.py
+++ b/qfluentwidgets/components/widgets/combo_box.py
@@ -189,7 +189,7 @@ class ComboBoxBase(QObject):
         if text in self.itemMap or not 0 <= index < len(self.items):
             return
 
-        item = self.itemMap.pop()
+        item = self.itemMap.pop(self.items[index].text)
         item.text = text
         self.itemMap[text] = item
         if self.currentIndex() == index:

--- a/qfluentwidgets/components/widgets/combo_box.py
+++ b/qfluentwidgets/components/widgets/combo_box.py
@@ -89,8 +89,6 @@ class ComboBoxBase(QObject):
 
         icon: str | QIcon | FluentIconBase
         """
-        if not text or text in self.itemMap:
-            return
 
         item = ComboItem(text, icon, userData)
         self.itemMap[text] = item
@@ -189,9 +187,7 @@ class ComboBoxBase(QObject):
         if text in self.itemMap or not 0 <= index < len(self.items):
             return
 
-        item = self.itemMap.pop(self.items[index].text)
-        item.text = text
-        self.itemMap[text] = item
+        self.items[index].text = text
         if self.currentIndex() == index:
             self.setText(text)
 


### PR DESCRIPTION
使用qtdesigner生成界面代码的时候，会用setItemText来为combobox选项赋值。但是self.itemMap.pop()缺少参数，会导致combobox无法正常使用。