### PR TITLE
Fixes #444

### DIFF
--- a/qfluentwidgets/components/settings/setting_card.py
+++ b/qfluentwidgets/components/settings/setting_card.py
@@ -186,7 +186,7 @@ class RangeSettingCard(SettingCard):
         self.hBoxLayout.addSpacing(16)
 
         self.valueLabel.setObjectName('valueLabel')
-        configItem.valueChanged.connect(self.setValue)
+        configItem.valueChanged.connect(lambda x: self.slider.setValue(x))
         self.slider.valueChanged.connect(self.__onValueChanged)
 
     def __onValueChanged(self, value: int):


### PR DESCRIPTION
### Fixes issue #444  
#### 结果
![out](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/23147652/50c0dd2f-c166-4063-a059-0c2bbb55246c)
#### 实现方法
替换 *self.setValue* 为 *lambda x: self.slider.setValue(x)*
slider在设置值后触发valueChanged信号，该信号已在下一行连接到*self.__onValueChanged*，它会去调用setValue设置label的值，就完成了对slider和label的设置

