### PR TITLE
修复切换动画会导致Y轴偏移的问题

### DIFF
--- a/qfluentwidgets/components/widgets/stacked_widget.py
+++ b/qfluentwidgets/components/widgets/stacked_widget.py
@@ -149,7 +149,7 @@ class PopUpAniStackedWidget(QStackedWidget):
         else:
             deltaX, deltaY = nextAniInfo.deltaX, nextAniInfo.deltaY
             pos = nextWidget.pos() + QPoint(deltaX, deltaY)
-            self.__setAnimation(ani, pos, QPoint(nextWidget.x(), self.y()), duration, easingCurve)
+            self.__setAnimation(ani, pos, QPoint(nextWidget.x(), 0), duration, easingCurve)
             super().setCurrentIndex(index)
 
         # start animation


### PR DESCRIPTION
![1](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/df953010-3e0c-4a39-8264-963f3279fcd7)
图一是正常打开的
![2](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/35ab5271-183e-4f62-a637-5a18e4802e5b)
图二是经过一次切换的
![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/51437dc4-e38a-439d-a7fd-792fd6537881)
仔细看这里出现了相较于Y轴的位置偏移

这是一个非常小的难以观察的问题，但是在此时如果界面中有任何 sizepolicy 或者 sizeconstraint 控件行为，或者窗口的 resize 行为，就会立即触发位置重置导致画面跳动。

经过排查，发现在 `PopUpAniStackedWidget` 中原本 pos 应当为 (0,0) 的初始值在 Qt中表现为 (1,1)
所以当 `self.__setAnimation(ani, pos, QPoint(nextWidget.x(), self.y()), duration, easingCurve)` 时，结束值为 `QPoint(nextWidget.x(), self.y())` 为 (0, 1) 造成了偏移如下图
![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/a3d9af9b-7380-413d-8bf0-c6dcca74bcd4)

解决方案是直接手动给出Y值为0，曾经考虑使用 `nextWidget.y()` 但是在快速反复切换的时候，该值也会不为0，所以，直接手动给出Y值为0我认为是最佳解决方案。

至于为什么原本 POS 的 Y值应当为0而是1，应该是Qt的BUG或者其他副作用导致，打印实际值为 （1，1） 但是如果真的设置为 1，1 会出现明显的 x y 双向偏移，所以这里应的 self.pos 应当不予以信任。
