### PR TITLE
修复 `ExpandLayout` 隐藏控件仍然占位

### DIFF
--- a/qfluentwidgets/components/layout/expand_layout.py
+++ b/qfluentwidgets/components/layout/expand_layout.py
@@ -74,6 +74,8 @@ class ExpandLayout(QLayout):
         width = rect.width() - margin.left() - margin.right()
 
         for i, w in enumerate(self.__widgets):
+            if not w.isVisible():
+                continue
             y += (i>0)*self.spacing()
             if move:
                 w.setGeometry(QRect(QPoint(x, y), QSize(width, w.height())))


### PR DESCRIPTION
#597 反馈了当设置控件隐藏后，被隐藏的控件依旧对布局进行占位。

经过分析发现，这是由于在 `__doLayout` 函数中，我们未考虑控件的可见性导致的，所以当遍历每个部件时，我们首先检查控件的 `isVisible` 属性来检查其可见性。

如果该控件不可见，则跳过该控件并继续处理下一个控件。