### PR TITLE
Only restart animation after destination change

### DIFF
--- a/qfluentwidgets/components/layout/flow_layout.py
+++ b/qfluentwidgets/components/layout/flow_layout.py
@@ -154,6 +154,7 @@ class FlowLayout(QLayout):
 
     def _doLayout(self, rect: QRect, move: bool):
         """ adjust widgets position according to the window size """
+        aniRestart = False
         margin = self.contentsMargins()
         x = rect.x() + margin.left()
         y = rect.y() + margin.top()
@@ -174,16 +175,18 @@ class FlowLayout(QLayout):
                 rowHeight = 0
 
             if move:
+                target = QRect(QPoint(x, y), item.sizeHint())
                 if not self.needAni:
-                    item.setGeometry(QRect(QPoint(x, y), item.sizeHint()))
-                else:
+                    item.setGeometry(target)
+                elif target != self._anis[i].endValue():
                     self._anis[i].stop()
-                    self._anis[i].setEndValue(QRect(QPoint(x, y), item.sizeHint()))
+                    self._anis[i].setEndValue(target)
+                    aniRestart = True
 
             x = nextX
             rowHeight = max(rowHeight, item.sizeHint().height())
 
-        if self.needAni:
+        if self.needAni and aniRestart:
             self._aniGroup.stop()
             self._aniGroup.start()
 


### PR DESCRIPTION
# 问题描述
`class FlowLayout`的动画效果会在多次快速改变组件宽度时出现卡顿
![bug](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/28977540/64c1f755-927d-4bec-ba10-4a79ae938efd)

# 问题原因
`FlowLayout._doLayout(self, rect: QRect, move: bool)` 会在每次调用时使用如下代码重启动画：
``` python
if self.needAni:
    self._aniGroup.stop()
    self._aniGroup.start()
```
以上代码会使得动画重启，不考虑调用函数时是否`move = True`，也不考虑动画的`endValue`是否发生改变

# 解决办法
使用标记`aniRestart:bool`来记录是否需要重启动画，每次更新组件位置时均使用如下代码判断是否**新的目标位置是否与上次设置的不同**，当存在组件的位置发生变化时，才将`aniRestart = True`
``` python
if move:
    target = QRect(QPoint(x, y), item.sizeHint())
    if not self.needAni:
        item.setGeometry(target)
    elif target != self._anis[i].endValue():
        self._anis[i].stop()
        self._anis[i].setEndValue(target)
        aniRestart = True
```
只有存在组件位置发生变化时，才重启动画：
``` python
if self.needAni and aniRestart:
    self._aniGroup.stop()
    self._aniGroup.start()
```

# 效果
![fix](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/28977540/d510c35c-cf8a-4682-a6c4-37345c8f642d)
