### PR TITLE
增加与WinUI Gallery一致的渐变透明效果

### DIFF
--- a/examples/gallery/app/view/home_interface.py
+++ b/examples/gallery/app/view/home_interface.py
@@ -1,6 +1,6 @@
 # coding:utf-8
 from PyQt5.QtCore import Qt, QRectF
-from PyQt5.QtGui import QPixmap, QPainter, QColor, QBrush, QPainterPath
+from PyQt5.QtGui import QPixmap, QPainter, QColor, QBrush, QPainterPath, QLinearGradient
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel
 
 from qfluentwidgets import ScrollArea, isDarkTheme, FluentIcon
@@ -70,18 +70,24 @@ class BannerWidget(QWidget):
 
         path = QPainterPath()
         path.setFillRule(Qt.WindingFill)
-        w, h = self.width(), 200
+        w, h = self.width(), self.height()
         path.addRoundedRect(QRectF(0, 0, w, h), 10, 10)
         path.addRect(QRectF(0, h-50, 50, 50))
         path.addRect(QRectF(w-50, 0, 50, 50))
         path.addRect(QRectF(w-50, h-50, 50, 50))
         path = path.simplified()
 
+        # init linear gradient effect
+        gradient = QLinearGradient(0, 0, 0, h)
+
         # draw background color
         if not isDarkTheme():
-            painter.fillPath(path, QColor(206, 216, 228))
+            gradient.setColorAt(0, QColor(207, 216, 228, 255))
+            gradient.setColorAt(1, QColor(207, 216, 228, 0))
         else:
-            painter.fillPath(path, QColor(0, 0, 0))
+            gradient.setColorAt(0, QColor(0, 0, 0, 255))
+            gradient.setColorAt(1, QColor(0, 0, 0, 0))
+        painter.fillPath(path, QBrush(gradient))
 
         # draw banner image
         pixmap = self.banner.scaled(

--- a/examples/gallery/app/view/home_interface.py
+++ b/examples/gallery/app/view/home_interface.py
@@ -92,7 +92,6 @@ class BannerWidget(QWidget):
         # draw banner image
         pixmap = self.banner.scaled(
             self.size(), transformMode=Qt.SmoothTransformation)
-        path.addRect(QRectF(0, h, w, self.height() - h))
         painter.fillPath(path, QBrush(pixmap))
 
 

--- a/examples/gallery/app/view/home_interface.py
+++ b/examples/gallery/app/view/home_interface.py
@@ -87,6 +87,7 @@ class BannerWidget(QWidget):
         else:
             gradient.setColorAt(0, QColor(0, 0, 0, 255))
             gradient.setColorAt(1, QColor(0, 0, 0, 0))
+            
         painter.fillPath(path, QBrush(gradient))
 
         # draw banner image


### PR DESCRIPTION
### 动机
PyQt-Fluent-Widgets 旨在提供一个 Fluent Design 的组件库，其中的重点是提供一个对标 WinUI3 Gallery 的组件相册体验，这是至关重要地。相册首页的 Banner 在 WinUI3 Gallery 中呈现渐变透明效果的，见下图，PyQt-Fluent-Widgets 未能呈现这一效果。所提供一个与 Fluent Design 官方相册一直地效果是有必要地，此外还能获得更加平滑的过度，消除突兀的颜色转折，和更好地外观。并为引入大的变动，总体来讲非常划算。
### 实现
使用 `QLinearGradient` 构造一个渐变对象并设置笔刷即可。
### 效果

**WinUI Gallery 中的渐变 Banner**

![WINUI](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/9c8b2528-385f-44a7-9467-36ef14cfe5d9)
![WINUI-DARK](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/35c9bde0-f5aa-4abc-8767-ccf0fed4299a)

**PyQt Fluent Widgets Gallery 原本没有渐变的 Banner 和转折处**

![QT](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/a2030806-d93c-4191-ad74-b778b4625100)
![QT-DARK](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/9c070db5-81ed-461f-b2fa-53b517c1c9e1)
![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/58582670-8d29-4baf-8a2d-3219eff0bc85)

**PyQt Fluent Widgets Gallery 增加渐变效果后转折处变得非常丝滑**

![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/aadf834b-0c65-4992-a2cb-e2a65e0728f9)
![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/a7aa8061-c422-47db-8812-edb9bf17f3e5)
![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/866d42f1-c431-419b-85df-9bd958a7f1ea)

**直观对比动画**

![动画](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/8cc65860-763b-482d-998c-1bc002aa8499)

**对比 WinUI 效果非常一致**
![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/5d5eed44-e067-476d-9e38-d030aa556657)
![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/cdf158ba-51a1-488d-b8a1-4b62163f6826)

**现在我们有了跟 WinUI Gallery 完全一致的渐变**
