### PR TITLE
修复 `Pivot` 组件在窗口 `resize` 事件下的位置偏移

### DIFF
--- a/qfluentwidgets/components/navigation/pivot.py
+++ b/qfluentwidgets/components/navigation/pivot.py
@@ -218,12 +218,11 @@ class Pivot(QWidget):
         return self.items[routeKey]
     
     def resizeEvent(self, e) -> None:
-        super().resizeEvent(e)
+            super().resizeEvent(e)
 
-        if self._currentRouteKey is not None:
-            currentItem = self.widget(self._currentRouteKey)
-            if currentItem:
-                self.slideAni.startAnimation(currentItem.x())
+            item = self.currentItem()
+            if item is not None:
+                self.slideAni.setValue(item.x())
 
     def paintEvent(self, e):
         super().paintEvent(e)

--- a/qfluentwidgets/components/navigation/pivot.py
+++ b/qfluentwidgets/components/navigation/pivot.py
@@ -216,6 +216,14 @@ class Pivot(QWidget):
             raise RouteKeyError(f"`{routeKey}` is illegal.")
 
         return self.items[routeKey]
+    
+    def resizeEvent(self, e) -> None:
+        super().resizeEvent(e)
+
+        if self._currentRouteKey is not None:
+            currentItem = self.widget(self._currentRouteKey)
+            if currentItem:
+                self.slideAni.startAnimation(currentItem.x())
 
     def paintEvent(self, e):
         super().paintEvent(e)


### PR DESCRIPTION
### 动机
当前 `Pivot` 组件在会在窗口 `resize` 事件下的位置偏移
### 原因
因为没有正确处理  `resize` 事件下的位置重绘
### 解决方案
通过 `resizeEvent` 正确 handle 事件