### PR TITLE
修复MaskDialogBase淡出动画

### DIFF
--- a/qfluentwidgets/components/dialog_box/mask_dialog_base.py
+++ b/qfluentwidgets/components/dialog_box/mask_dialog_base.py
@@ -57,19 +57,31 @@ class MaskDialogBase(QDialog):
         opacityAni.start()
         super().showEvent(e)
 
-    def closeEvent(self, e):
-        """ fade out """
+    def accept(self):
+        """ hide dialog box """
         self.widget.setGraphicsEffect(None)
         opacityEffect = QGraphicsOpacityEffect(self)
         self.setGraphicsEffect(opacityEffect)
         opacityAni = QPropertyAnimation(opacityEffect, b'opacity', self)
         opacityAni.setStartValue(1)
         opacityAni.setEndValue(0)
-        opacityAni.setDuration(100)
+        opacityAni.setDuration(200)
         opacityAni.setEasingCurve(QEasingCurve.OutCubic)
-        opacityAni.finished.connect(self.deleteLater)
+        opacityAni.finished.connect(lambda: self.done(QDialog.Accepted))
         opacityAni.start()
-        e.ignore()
+
+    def reject(self):
+        """ hide dialog box """
+        self.widget.setGraphicsEffect(None)
+        opacityEffect = QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(opacityEffect)
+        opacityAni = QPropertyAnimation(opacityEffect, b'opacity', self)
+        opacityAni.setStartValue(1)
+        opacityAni.setEndValue(0)
+        opacityAni.setDuration(200)
+        opacityAni.setEasingCurve(QEasingCurve.OutCubic)
+        opacityAni.finished.connect(lambda: self.done(QDialog.Rejected))
+        opacityAni.start()
 
     def resizeEvent(self, e):
         self.windowMask.resize(self.size())

--- a/qfluentwidgets/components/dialog_box/mask_dialog_base.py
+++ b/qfluentwidgets/components/dialog_box/mask_dialog_base.py
@@ -71,6 +71,19 @@ class MaskDialogBase(QDialog):
         opacityAni.start()
         e.ignore()
 
+    def done(self, a0):
+        self.widget.setGraphicsEffect(None)
+        opacityEffect = QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(opacityEffect)
+        opacityAni = QPropertyAnimation(opacityEffect, b"opacity", self)
+        opacityAni.setStartValue(1)
+        opacityAni.setEndValue(0)
+        opacityAni.setDuration(100)
+        opacityAni.setEasingCurve(QEasingCurve.OutCubic)
+        opacityAni.finished.connect(lambda: QDialog.done(self, a0))
+        opacityAni.finished.connect(opacityAni.deleteLater)
+        opacityAni.start()
+
     def resizeEvent(self, e):
         self.windowMask.resize(self.size())
 

--- a/qfluentwidgets/components/dialog_box/mask_dialog_base.py
+++ b/qfluentwidgets/components/dialog_box/mask_dialog_base.py
@@ -57,31 +57,19 @@ class MaskDialogBase(QDialog):
         opacityAni.start()
         super().showEvent(e)
 
-    def accept(self):
-        """ hide dialog box """
+    def closeEvent(self, e):
+        """ fade out """
         self.widget.setGraphicsEffect(None)
         opacityEffect = QGraphicsOpacityEffect(self)
         self.setGraphicsEffect(opacityEffect)
         opacityAni = QPropertyAnimation(opacityEffect, b'opacity', self)
         opacityAni.setStartValue(1)
         opacityAni.setEndValue(0)
-        opacityAni.setDuration(200)
+        opacityAni.setDuration(100)
         opacityAni.setEasingCurve(QEasingCurve.OutCubic)
-        opacityAni.finished.connect(lambda: self.done(QDialog.Accepted))
+        opacityAni.finished.connect(self.deleteLater)
         opacityAni.start()
-
-    def reject(self):
-        """ hide dialog box """
-        self.widget.setGraphicsEffect(None)
-        opacityEffect = QGraphicsOpacityEffect(self)
-        self.setGraphicsEffect(opacityEffect)
-        opacityAni = QPropertyAnimation(opacityEffect, b'opacity', self)
-        opacityAni.setStartValue(1)
-        opacityAni.setEndValue(0)
-        opacityAni.setDuration(200)
-        opacityAni.setEasingCurve(QEasingCurve.OutCubic)
-        opacityAni.finished.connect(lambda: self.done(QDialog.Rejected))
-        opacityAni.start()
+        e.ignore()
 
     def resizeEvent(self, e):
         self.windowMask.resize(self.size())


### PR DESCRIPTION
问题:原先MaskDialogBase的淡出动画没有生效。

原因是:继承自QDialog的MaskDialogBase在accept和reject关闭的时候不是close而是hide，所以没有能执行淡出动画

解决方案:我把逻辑放到accept和reject里了(动画结束后:执行self.done(QDialog.Accept)或者self.done(QDialog.Reject)

效果对比:

https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/39639716/a05f95bf-93be-4395-ae08-c347580f0acd


https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/39639716/269533f0-6454-4786-a37a-590605d08b05

