### PR TITLE
修复 `FlowLayout` 偶发地组件堆叠和快速调整窗口大小导致的组件位置阻塞

### DIFF
--- a/qfluentwidgets/components/layout/flow_layout.py
+++ b/qfluentwidgets/components/layout/flow_layout.py
@@ -1,8 +1,8 @@
 # coding:utf-8
 from typing import List
 
-from PyQt5.QtCore import QSize, QPoint, Qt, QRect, QPropertyAnimation, QParallelAnimationGroup, QEasingCurve, QEvent, QTimer
-from PyQt5.QtWidgets import QLayout, QWidgetItem, QLayoutItem, QWidget
+from PyQt5.QtCore import QSize, QPoint, Qt, QRect, QPropertyAnimation, QParallelAnimationGroup, QEasingCurve, QEvent, QTimer, QObject
+from PyQt5.QtWidgets import QLayout, QWidgetItem, QLayoutItem
 
 
 class FlowLayout(QLayout):
@@ -34,7 +34,7 @@ class FlowLayout(QLayout):
         self._deBounceTimer = QTimer(self)
         self._deBounceTimer.setSingleShot(True)
         self._deBounceTimer.timeout.connect(lambda: self._doLayout(self.geometry(), True))
-        if isinstance(self.parent(), QWidget) or isinstance(self.parent(), QLayout):
+        if parent:
             self.parent().installEventFilter(self)
 
 

--- a/qfluentwidgets/components/layout/flow_layout.py
+++ b/qfluentwidgets/components/layout/flow_layout.py
@@ -36,9 +36,6 @@ class FlowLayout(QLayout):
         self._deBounceTimer.timeout.connect(lambda: self._doLayout(self.geometry(), True))
         self._isInstalledEventFilter = False
         self._wParent = None
-        if self.parent():
-            self.parent().installEventFilter(self)
-            self._isInstalledEventFilter = True
 
     def addItem(self, item):
         self._items.append(item)
@@ -167,14 +164,11 @@ class FlowLayout(QLayout):
         if event.type() == QEvent.Type.ParentChange:
             self._wParent = obj.parent()
             obj.parent().installEventFilter(self)
+            self._isInstalledEventFilter = True
 
         if obj == self._wParent and event.type() == QEvent.Type.Show:
             self._doLayout(self.geometry(), True)
-            self._isInstalledEventFilter = True
 
-        if obj == self.parent() and event.type() == QEvent.Type.Show:
-            self._doLayout(self.geometry(), True)
-        
         return super().eventFilter(obj, event)
 
     def _doLayout(self, rect: QRect, move: bool):

--- a/qfluentwidgets/components/layout/flow_layout.py
+++ b/qfluentwidgets/components/layout/flow_layout.py
@@ -34,15 +34,16 @@ class FlowLayout(QLayout):
         self._deBounceTimer = QTimer(self)
         self._deBounceTimer.setSingleShot(True)
         self._deBounceTimer.timeout.connect(lambda: self._doLayout(self.geometry(), True))
-        if parent:
-            self.parent().installEventFilter(self)
-
+        self._isInstalledEventFilter = False
 
     def addItem(self, item):
         self._items.append(item)
 
     def addWidget(self, w):
         super().addWidget(w)
+        if not self._isInstalledEventFilter:
+            w.parent().installEventFilter(self) if w.parent() else None
+
         if not self.needAni:
             return
 

--- a/qfluentwidgets/components/layout/flow_layout.py
+++ b/qfluentwidgets/components/layout/flow_layout.py
@@ -133,7 +133,11 @@ class FlowLayout(QLayout):
 
     def setGeometry(self, rect: QRect):
         super().setGeometry(rect)
-        self._deBounceTimer.start(80)
+        
+        if self.needAni:
+            self._deBounceTimer.start(80)
+        else:
+            self._doLayout(rect, True)
 
     def sizeHint(self):
         return self.minimumSize()
@@ -188,7 +192,7 @@ class FlowLayout(QLayout):
         spaceY = self.verticalSpacing()
 
         for i, item in enumerate(self._items):
-            if item.widget() and not item.widget().isHidden() and self.isTight:
+            if item.widget() and not item.widget().isVisible() and self.isTight:
                 continue
 
             nextX = x + item.sizeHint().width() + spaceX

--- a/qfluentwidgets/components/layout/flow_layout.py
+++ b/qfluentwidgets/components/layout/flow_layout.py
@@ -161,7 +161,7 @@ class FlowLayout(QLayout):
         return self._horizontalSpacing
     
     def eventFilter(self, obj: QObject, event: QEvent) -> bool:
-        if event.type() == QEvent.Type.ParentChange:
+        if obj in self.children() and event.type() == QEvent.Type.ParentChange:
             self._wParent = obj.parent()
             obj.parent().installEventFilter(self)
             self._isInstalledEventFilter = True

--- a/qfluentwidgets/components/layout/flow_layout.py
+++ b/qfluentwidgets/components/layout/flow_layout.py
@@ -35,6 +35,7 @@ class FlowLayout(QLayout):
         self._deBounceTimer.setSingleShot(True)
         self._deBounceTimer.timeout.connect(lambda: self._doLayout(self.geometry(), True))
         self._wParent = None
+        self._isInstalledEventFilter = False
 
     def addItem(self, item):
         self._items.append(item)
@@ -42,11 +43,12 @@ class FlowLayout(QLayout):
     def addWidget(self, w):
         super().addWidget(w)
 
-        if w.parent():
-            self._wParent = w.parent()
-            w.parent().installEventFilter(self)
-        else:
-            w.installEventFilter(self)
+        if not self._isInstalledEventFilter:
+            if w.parent():
+                self._wParent = w.parent()
+                w.parent().installEventFilter(self)
+            else:
+                w.installEventFilter(self)
 
         if not self.needAni:
             return
@@ -167,9 +169,11 @@ class FlowLayout(QLayout):
         if obj in [w.widget() for w in self._items] and event.type() == QEvent.Type.ParentChange:
             self._wParent = obj.parent()
             obj.parent().installEventFilter(self)
+            self._isInstalledEventFilter = True
 
         if obj == self._wParent and event.type() == QEvent.Type.Show:
             self._doLayout(self.geometry(), True)
+            self._isInstalledEventFilter = True
 
         return super().eventFilter(obj, event)
 

--- a/qfluentwidgets/components/layout/flow_layout.py
+++ b/qfluentwidgets/components/layout/flow_layout.py
@@ -34,7 +34,8 @@ class FlowLayout(QLayout):
         self._deBounceTimer = QTimer(self)
         self._deBounceTimer.setSingleShot(True)
         self._deBounceTimer.timeout.connect(lambda: self._doLayout(self.geometry(), True))
-        self.parentWidget().installEventFilter(self) if isinstance(parent, QWidget) else ...
+        if isinstance(self.parent(), QWidget) or isinstance(self.parent(), QLayout):
+            self.parent().installEventFilter(self)
 
 
     def addItem(self, item):

--- a/qfluentwidgets/components/layout/flow_layout.py
+++ b/qfluentwidgets/components/layout/flow_layout.py
@@ -34,7 +34,6 @@ class FlowLayout(QLayout):
         self._deBounceTimer = QTimer(self)
         self._deBounceTimer.setSingleShot(True)
         self._deBounceTimer.timeout.connect(lambda: self._doLayout(self.geometry(), True))
-        self._isInstalledEventFilter = False
         self._wParent = None
 
     def addItem(self, item):
@@ -42,12 +41,12 @@ class FlowLayout(QLayout):
 
     def addWidget(self, w):
         super().addWidget(w)
-        if not self._isInstalledEventFilter:
-            if w.parent():
-                self._wParent = w.parent()
-                w.parent().installEventFilter(self)
-            else:
-                w.installEventFilter(self)
+
+        if w.parent():
+            self._wParent = w.parent()
+            w.parent().installEventFilter(self)
+        else:
+            w.installEventFilter(self)
 
         if not self.needAni:
             return
@@ -168,10 +167,8 @@ class FlowLayout(QLayout):
         if obj in [w.widget() for w in self._items] and event.type() == QEvent.Type.ParentChange:
             self._wParent = obj.parent()
             obj.parent().installEventFilter(self)
-            self._isInstalledEventFilter = True
 
         if obj == self._wParent and event.type() == QEvent.Type.Show:
-            self._isInstalledEventFilter = True
             self._doLayout(self.geometry(), True)
 
         return super().eventFilter(obj, event)

--- a/qfluentwidgets/components/layout/flow_layout.py
+++ b/qfluentwidgets/components/layout/flow_layout.py
@@ -42,7 +42,8 @@ class FlowLayout(QLayout):
     def addWidget(self, w):
         super().addWidget(w)
         if not self._isInstalledEventFilter:
-            w.parent().installEventFilter(self) if w.parent() else None
+            w.installEventFilter(self)
+            self._isInstalledEventFilter = True
 
         if not self.needAni:
             return
@@ -160,7 +161,7 @@ class FlowLayout(QLayout):
         return self._horizontalSpacing
     
     def eventFilter(self, obj, event: QEvent) -> bool:
-        if event.type() == QEvent.Type.Show:
+        if event.type() == QEvent.Type.ParentChange:
             self._doLayout(self.geometry(), True)
         
         return super().eventFilter(obj, event)


### PR DESCRIPTION
## 动机
- 在使用流式布局时，当组件是延迟加载或者需要网络加载没有第一事件布局的时候，这时如果当你不在当前 View，就会导致组件堆叠无法正常布局。
- 当快速调整窗口大小的时候，组件会在错误的位置阻塞直至停止调整窗口大小。
## 原因
- 当当前 View 没有显示的时候，`FlowLayout` 未能完成布局，当再次显示的时候并不能触发 `setGeometry` 函数进而无法调用 `_doLayout` 进行布局导致堆叠。
- 快速调整窗口大小会重复快速调用 `setGeometry` 进而调用 `_doLayout` 进行大量计算和导致组件阻塞。
## 解决方案
- 通过对流式布局的父组件安装一个事件过滤器，过滤其显示事件，这样当父组件显示的时候，就能进行布局，如果已经完成布局，组件不会做任何位置动作。
- 通过添加一个毫秒级防抖计时器，当每次调整窗口大小时触发 `setGeometry` 的时候刷新该计时器，直到停止重新调整进行布局，对与动态布局，添加防抖是很有必要的。
## 效果对比
https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/c6448d9e-284b-4369-a9ac-5003e8c38ce0

https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/63f79abc-8af2-454c-a4b9-b9bc35ad6ffc

https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/e7cafda1-2a03-43aa-9c96-3980d4a05030


