### PR TITLE
修复显示商业组件库提示的时候导致的 `UnicodeEncodeError`

### DIFF
--- a/qfluentwidgets/common/config.py
+++ b/qfluentwidgets/common/config.py
@@ -12,6 +12,9 @@ from PyQt5.QtGui import QColor
 from .exception_handler import exceptionHandler
 
 
+ALERT = "\n\033[1;33m📢 Tips:\033[0m QFluentWidgets Pro is now released. Click \033[1;96mhttps://qfluentwidgets.com/pages/pro\033[0m to learn more about it.\n"
+
+
 class Theme(Enum):
     """ Theme enumeration """
 
@@ -401,7 +404,10 @@ class QConfig(QObject):
 
 
 qconfig = QConfig()
-print("\n\033[1;33m📢 Tips:\033[0m QFluentWidgets Pro is now released. Click \033[1;96mhttps://qfluentwidgets.com/pages/pro\033[0m to learn more about it.\n")
+try:
+    print(ALERT)
+except UnicodeEncodeError:
+    print(ALERT.replace("📢", ""))
 
 
 def isDarkTheme():


### PR DESCRIPTION
## 动机
当在某些特殊条件下启动会提示 `UnicodeEncodeError` 直接报错。
## 原因
是在 `config` 模块中打印提示商业组件库导致的，因为在某些原生 Windows 窗体中或者某些情况下，无法解码 `Unicode` 的 Emoji，因为这些系统默认解码为 `CJK`
## 结局方案
尝试打印，如果失败则替换其中的 Emoji，经过一些测试，问题解决。