### PR TITLE
修复面包屑字体遮挡BUG

### DIFF
--- a/qfluentwidgets/components/navigation/breadcrumb.py
+++ b/qfluentwidgets/components/navigation/breadcrumb.py
@@ -1,4 +1,5 @@
 # coding:utf-8
+import math
 from typing import Dict, List
 from PyQt5.QtCore import Qt, pyqtSignal, QRectF, pyqtProperty, QPoint, QEvent
 from PyQt5.QtGui import QPainter, QFont, QHoverEvent
@@ -81,7 +82,8 @@ class BreadcrumbItem(BreadcrumbWidget):
         self.text = text
 
         rect = self.fontMetrics().boundingRect(text)
-        w = rect.width() + 1
+        added = math.ceil(self.font().pixelSize() / 10)
+        w = rect.width() + added
         if not self.isRoot():
             w += self.spacing * 2
 


### PR DESCRIPTION
面包屑字体越大被遮挡部分越多，获取字体大小再除10最后向上取整，矩形范围加上计算出来的结果。
面包屑的字体每增加10点像素点就会被遮挡住一部分，通过这种方式可以动态的根据面包屑字体大小来扩大矩形宽度来绘制。