### PR TITLE
修复面包屑字体被遮挡BUG

### DIFF
--- a/qfluentwidgets/components/navigation/breadcrumb.py
+++ b/qfluentwidgets/components/navigation/breadcrumb.py
@@ -1,4 +1,5 @@
 # coding:utf-8
+import math
 from typing import Dict, List
 from PyQt5.QtCore import Qt, pyqtSignal, QRectF, pyqtProperty, QPoint, QEvent
 from PyQt5.QtGui import QPainter, QFont, QHoverEvent
@@ -81,7 +82,8 @@ class BreadcrumbItem(BreadcrumbWidget):
         self.text = text
 
         rect = self.fontMetrics().boundingRect(text)
-        w = rect.width() + 1
+        added = math.ceil(self.font().pixelSize() / 10)
+        w = rect.width() + added
         if not self.isRoot():
             w += self.spacing * 2
 

--- a/qfluentwidgets/components/navigation/breadcrumb.py
+++ b/qfluentwidgets/components/navigation/breadcrumb.py
@@ -1,5 +1,4 @@
 # coding:utf-8
-import math
 from typing import Dict, List
 from PyQt5.QtCore import Qt, pyqtSignal, QRectF, pyqtProperty, QPoint, QEvent
 from PyQt5.QtGui import QPainter, QFont, QHoverEvent
@@ -82,8 +81,7 @@ class BreadcrumbItem(BreadcrumbWidget):
         self.text = text
 
         rect = self.fontMetrics().boundingRect(text)
-        added = math.ceil(self.font().pixelSize() / 10)
-        w = rect.width() + added
+        w = rect.width() + 1
         if not self.isRoot():
             w += self.spacing * 2
 

--- a/qfluentwidgets/components/navigation/breadcrumb.py
+++ b/qfluentwidgets/components/navigation/breadcrumb.py
@@ -83,8 +83,7 @@ class BreadcrumbItem(BreadcrumbWidget):
         self.text = text
 
         rect = self.fontMetrics().boundingRect(text)
-        added = math.ceil(self.font().pixelSize() / 10)
-        w = rect.width() + added
+        w = rect.width() + math.ceil(self.font().pixelSize() / 10)
         if not self.isRoot():
             w += self.spacing * 2
 

--- a/qfluentwidgets/components/navigation/breadcrumb.py
+++ b/qfluentwidgets/components/navigation/breadcrumb.py
@@ -1,4 +1,6 @@
 # coding:utf-8
+import math
+
 from typing import Dict, List
 from PyQt5.QtCore import Qt, pyqtSignal, QRectF, pyqtProperty, QPoint, QEvent
 from PyQt5.QtGui import QPainter, QFont, QHoverEvent
@@ -81,7 +83,8 @@ class BreadcrumbItem(BreadcrumbWidget):
         self.text = text
 
         rect = self.fontMetrics().boundingRect(text)
-        w = rect.width() + 1
+        added = math.ceil(self.font().pixelSize() / 10)
+        w = rect.width() + added
         if not self.isRoot():
             w += self.spacing * 2
 


### PR DESCRIPTION
面包屑字体每增加10像素就会被遮挡1像素，根据这个规律**字体大小除10向上取整**就是要增加的矩形宽度。
