### PR TITLE
Make the pyside6-designer plugins work.

### DIFF
--- a/plugins/basic_input_plugin.py
+++ b/plugins/basic_input_plugin.py
@@ -1,0 +1,491 @@
+# coding: utf-8
+import traceback
+try:
+    from PySide6.QtDesigner import QDesignerCustomWidgetInterface
+
+    from qfluentwidgets import (PrimaryPushButton, SplitPushButton, DropDownPushButton,
+                                ToolButton, SplitToolButton, DropDownToolButton, FluentIcon, ToggleButton,
+                                SwitchButton, RadioButton, CheckBox, HyperlinkButton, Slider, ComboBox, IconWidget,
+                                EditableComboBox, PixmapLabel, PushButton, PrimaryToolButton, PrimarySplitToolButton,
+                                PrimarySplitPushButton, PrimaryDropDownPushButton, PrimaryDropDownToolButton,
+                                TransparentToolButton, TransparentPushButton, ToggleToolButton, TransparentToggleToolButton,
+                                TransparentTogglePushButton, TransparentDropDownPushButton, TransparentDropDownToolButton,
+                                PillPushButton, PillToolButton, HorizontalSeparator, VerticalSeparator)
+
+    from plugin_base import PluginBase
+    from task_menu_factory import EditTextTaskMenuFactory
+except:
+    with open('error.txt', 'w', encoding='utf-8') as f:
+        f.write(traceback.format_exc())
+
+
+class BasicInputPlugin(PluginBase):
+
+    def group(self):
+        return super().group() + ' (Basic Input)'
+
+
+class TextPlugin(BasicInputPlugin):
+
+    def domXml(self):
+        return f"""
+        <widget class="{self.name()}" name="{self.name()}">
+            <property name="text">
+                <string>{self.toolTip()}</string>
+            </property>
+        </widget>
+        """
+
+
+class CheckBoxPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Check box plugin """
+
+    def createWidget(self, parent):
+        return CheckBox(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('Checkbox')
+
+    def name(self):
+        return "CheckBox"
+
+
+class ComboBoxPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Combo box plugin """
+
+    def createWidget(self, parent):
+        return ComboBox(parent)
+
+    def icon(self):
+        return super().icon('ComboBox')
+
+    def name(self):
+        return "ComboBox"
+
+
+class EditableComboBoxPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Editable box plugin """
+
+    def createWidget(self, parent):
+        return EditableComboBox(parent)
+
+    def icon(self):
+        return super().icon('ComboBox')
+
+    def name(self):
+        return "EditableComboBox"
+
+
+class HyperlinkButtonPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Hyperlink button plugin """
+
+    def createWidget(self, parent):
+        return HyperlinkButton('', self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('HyperlinkButton')
+
+    def name(self):
+        return "HyperlinkButton"
+
+
+class PushButtonPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Push button plugin """
+
+    def createWidget(self, parent):
+        return PushButton(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('Button')
+
+    def name(self):
+        return "PushButton"
+
+
+class PrimaryPushButtonPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Primary push button plugin """
+
+    def createWidget(self, parent):
+        return PrimaryPushButton(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('Button')
+
+    def name(self):
+        return "PrimaryPushButton"
+
+
+class PillPushButtonPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Pill push button plugin """
+
+    def createWidget(self, parent):
+        return PillPushButton(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('Button')
+
+    def name(self):
+        return "PillPushButton"
+
+
+class DropDownPushButtonPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Drop down push button plugin """
+
+    def createWidget(self, parent):
+        return DropDownPushButton(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('DropDownButton')
+
+    def name(self):
+        return "DropDownPushButton"
+
+
+class PrimaryDropDownPushButtonPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Primary drop down push button plugin """
+
+    def createWidget(self, parent):
+        return PrimaryDropDownPushButton(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('DropDownButton')
+
+    def name(self):
+        return "PrimaryDropDownPushButton"
+
+
+@EditTextTaskMenuFactory.register
+class SplitPushButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Split push button plugin """
+
+    def createWidget(self, parent):
+        return SplitPushButton(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('SplitButton')
+
+    def name(self):
+        return "SplitPushButton"
+
+    def domXml(self):
+        return f"""
+        <widget class="{self.name()}" name="{self.name()}">
+            <property name="text_">
+                <string>{self.toolTip()}</string>
+            </property>
+        </widget>
+        """
+
+
+@EditTextTaskMenuFactory.register
+class PrimarySplitPushButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Primary color split push button plugin """
+
+    def createWidget(self, parent):
+        return PrimarySplitPushButton(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('SplitButton')
+
+    def name(self):
+        return "PrimarySplitPushButton"
+
+    def domXml(self):
+        return f"""
+        <widget class="{self.name()}" name="{self.name()}">
+            <property name="text_">
+                <string>{self.toolTip()}</string>
+            </property>
+        </widget>
+        """
+
+
+class ToolButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Tool button plugin """
+
+    def createWidget(self, parent):
+        return ToolButton(FluentIcon.BASKETBALL, parent)
+
+    def icon(self):
+        return super().icon('Button')
+
+    def name(self):
+        return "ToolButton"
+
+
+class PrimaryToolButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Primary color tool button plugin """
+
+    def createWidget(self, parent):
+        return PrimaryToolButton(FluentIcon.BASKETBALL, parent)
+
+    def icon(self):
+        return super().icon('Button')
+
+    def name(self):
+        return "PrimaryToolButton"
+
+
+class PillToolButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Pill tool button plugin """
+
+    def createWidget(self, parent):
+        return PillToolButton(FluentIcon.BASKETBALL, parent)
+
+    def icon(self):
+        return super().icon('Button')
+
+    def name(self):
+        return "PillToolButton"
+
+
+class TransparentToolButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Primary color tool button plugin """
+
+    def createWidget(self, parent):
+        return TransparentToolButton(FluentIcon.BASKETBALL, parent)
+
+    def icon(self):
+        return super().icon('Button')
+
+    def name(self):
+        return "TransparentToolButton"
+
+
+class DropDownToolButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Drop down tool button plugin """
+
+    def createWidget(self, parent):
+        return DropDownToolButton(FluentIcon.BASKETBALL, parent)
+
+    def icon(self):
+        return super().icon('DropDownButton')
+
+    def name(self):
+        return "DropDownToolButton"
+
+
+class PrimaryDropDownToolButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Drop down tool button plugin """
+
+    def createWidget(self, parent):
+        return PrimaryDropDownToolButton(FluentIcon.BASKETBALL, parent)
+
+    def icon(self):
+        return super().icon('DropDownButton')
+
+    def name(self):
+        return "PrimaryDropDownToolButton"
+
+
+class SplitToolButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ split tool button plugin """
+
+    def createWidget(self, parent):
+        return SplitToolButton(FluentIcon.BASKETBALL, parent)
+
+    def icon(self):
+        return super().icon('SplitButton')
+
+    def name(self):
+        return "SplitToolButton"
+
+
+class PrimarySplitToolButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Primary color split tool button plugin """
+
+    def createWidget(self, parent):
+        return PrimarySplitToolButton(FluentIcon.BASKETBALL, parent)
+
+    def icon(self):
+        return super().icon('SplitButton')
+
+    def name(self):
+        return "PrimarySplitToolButton"
+
+
+@EditTextTaskMenuFactory.register
+class SwitchButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Switch button plugin """
+
+    def createWidget(self, parent):
+        return SwitchButton(parent)
+
+    def icon(self):
+        return super().icon('ToggleSwitch')
+
+    def name(self):
+        return "SwitchButton"
+
+
+class RadioButtonPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Radio button plugin """
+
+    def createWidget(self, parent):
+        return RadioButton(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('RadioButton')
+
+    def name(self):
+        return "RadioButton"
+
+
+class ToggleButtonPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Toggle push button plugin """
+
+    def createWidget(self, parent):
+        return ToggleButton(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('ToggleButton')
+
+    def name(self):
+        return "ToggleButton"
+
+
+class ToggleToolButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Toggle tool button plugin """
+
+    def createWidget(self, parent):
+        return ToggleToolButton(FluentIcon.BASKETBALL, parent)
+
+    def icon(self):
+        return super().icon('ToggleButton')
+
+    def name(self):
+        return "ToggleToolButton"
+
+
+class TransparentPushButtonPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Transparent push button plugin """
+
+    def createWidget(self, parent):
+        return TransparentPushButton(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('Button')
+
+    def name(self):
+        return "TransparentPushButton"
+
+
+class TransparentTogglePushButtonPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Transparent toggle push button plugin """
+
+    def createWidget(self, parent):
+        return TransparentTogglePushButton(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('ToggleButton')
+
+    def name(self):
+        return "TransparentTogglePushButton"
+
+
+class TransparentDropDownPushButtonPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Transparent drop down push button plugin """
+
+    def createWidget(self, parent):
+        return TransparentDropDownPushButton(self.toolTip(), parent)
+
+    def icon(self):
+        return super().icon('DropDownButton')
+
+    def name(self):
+        return "TransparentDropDownPushButton"
+
+
+class TransparentToggleToolButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Transparent toggle tool button plugin """
+
+    def createWidget(self, parent):
+        return TransparentToggleToolButton(FluentIcon.BASKETBALL, parent)
+
+    def icon(self):
+        return super().icon('ToggleButton')
+
+    def name(self):
+        return "TransparentToggleToolButton"
+
+
+class TransparentDropDownToolButtonPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Transparent drop down tool button plugin """
+
+    def createWidget(self, parent):
+        return TransparentDropDownToolButton(FluentIcon.BASKETBALL, parent)
+
+    def icon(self):
+        return super().icon('DropDownButton')
+
+    def name(self):
+        return "TransparentDropDownToolButton"
+
+
+class SliderPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """  Slider  plugin """
+
+    def createWidget(self, parent):
+        slider = Slider(parent)
+        slider.setRange(0, 100)
+        slider.setMinimumWidth(200)
+        return slider
+
+    def icon(self):
+        return super().icon('Slider')
+
+    def name(self):
+        return "Slider"
+
+
+class IconWidgetPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Icon widget plugin """
+
+    def createWidget(self, parent):
+        return IconWidget(FluentIcon.EMOJI_TAB_SYMBOLS, parent)
+
+    def icon(self):
+        return super().icon('IconElement')
+
+    def name(self):
+        return "IconWidget"
+
+
+class PixmapLabelPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Pixmap label plugin """
+
+    def createWidget(self, parent):
+        return PixmapLabel(parent)
+
+    def icon(self):
+        return super().icon('Image')
+
+    def name(self):
+        return "PixmapLabel"
+
+
+class HorizontalSeparatorPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Horizontal separator plugin """
+
+    def createWidget(self, parent):
+        return HorizontalSeparator(parent)
+
+    def icon(self):
+        return super().icon('Line')
+
+    def name(self):
+        return "HorizontalSeparator"
+
+
+class VerticalSeparatorPlugin(BasicInputPlugin, QDesignerCustomWidgetInterface):
+    """ Vertical separator plugin """
+
+    def createWidget(self, parent):
+        return VerticalSeparator(parent)
+
+    def icon(self):
+        return super().icon('VerticalLine')
+
+    def name(self):
+        return "VerticalSeparator"
+

--- a/plugins/container_plugin.py
+++ b/plugins/container_plugin.py
@@ -1,0 +1,228 @@
+# coding: utf-8
+from PySide6.QtWidgets import QWidget
+from PySide6.QtDesigner import (QDesignerCustomWidgetInterface, QDesignerFormWindowInterface, QExtensionFactory,
+                              QPyDesignerContainerExtension)
+
+from qfluentwidgets import (ScrollArea, SmoothScrollArea, SingleDirectionScrollArea, OpacityAniStackedWidget,
+                            PopUpAniStackedWidget, CardWidget, ElevatedCardWidget, SimpleCardWidget,
+                            HeaderCardWidget)
+
+from plugin_base import PluginBase
+
+
+class ContainerPlugin(PluginBase):
+
+    def group(self):
+        return super().group() + ' (Container)'
+
+    def isContainer(self):
+        return True
+
+
+class CardWidgetPlugin(ContainerPlugin, QDesignerCustomWidgetInterface):
+    """ Card widget plugin """
+
+    def createWidget(self, parent):
+        return CardWidget(parent)
+
+    def icon(self):
+        return super().icon("CommandBar")
+
+    def name(self):
+        return "CardWidget"
+
+
+class ElevatedCardWidgetPlugin(ContainerPlugin, QDesignerCustomWidgetInterface):
+    """ Elevated card widget plugin """
+
+    def createWidget(self, parent):
+        return ElevatedCardWidget(parent)
+
+    def icon(self):
+        return super().icon("CommandBar")
+
+    def name(self):
+        return "ElevatedCardWidget"
+
+
+class SimpleCardWidgetPlugin(ContainerPlugin, QDesignerCustomWidgetInterface):
+    """ Simple card widget plugin """
+
+    def createWidget(self, parent):
+        return SimpleCardWidget(parent)
+
+    def icon(self):
+        return super().icon("CommandBar")
+
+    def name(self):
+        return "SimpleCardWidget"
+
+
+class HeaderCardWidgetPlugin(ContainerPlugin, QDesignerCustomWidgetInterface):
+    """ Header card widget plugin """
+
+    def createWidget(self, parent):
+        return HeaderCardWidget(parent)
+
+    def icon(self):
+        return super().icon("CommandBar")
+
+    def name(self):
+        return "HeaderCardWidget"
+
+
+class ScrollAreaPluginBase(ContainerPlugin):
+    """ Scroll area plugin base """
+
+    def domXml(self):
+        return f"""
+            <widget class="{self.name()}" name="{self.name()}">
+                <property name="widgetResizable">
+                    <bool>true</bool>
+                </property>
+                <widget class="QWidget" name="scrollAreaWidgetContents" />
+            </widget>
+        """
+
+
+class ScrollAreaPlugin(ScrollAreaPluginBase, QDesignerCustomWidgetInterface):
+    """ Scroll area plugin """
+
+    def createWidget(self, parent):
+        return ScrollArea(parent)
+
+    def icon(self):
+        return super().icon("ScrollViewer")
+
+    def name(self):
+        return "ScrollArea"
+
+    def toolTip(self):
+        return "Smooth scroll area"
+
+
+class SmoothScrollAreaPlugin(ScrollAreaPluginBase, QDesignerCustomWidgetInterface):
+    """ Smooth scroll area plugin """
+
+    def createWidget(self, parent):
+        return SmoothScrollArea(parent)
+
+    def icon(self):
+        return super().icon("ScrollViewer")
+
+    def name(self):
+        return "SmoothScrollArea"
+
+
+class SingleDirectionScrollAreaPlugin(ScrollAreaPluginBase, QDesignerCustomWidgetInterface):
+    """ Single direction scroll area plugin """
+
+    def createWidget(self, parent):
+        return SingleDirectionScrollArea(parent)
+
+    def icon(self):
+        return super().icon("ScrollViewer")
+
+    def name(self):
+        return "SingleDirectionScrollArea"
+
+
+class StackedWidgetPlugin(ContainerPlugin):
+
+    def domXml(self):
+        return f"""
+            <widget class="{self.name()}" name="{self.name()}">'
+                <widget class="QWidget" name="page" />'
+            </widget>
+        """
+
+    def onCurrentIndexChanged(self, index):
+        widget = self.sender()
+        form = QDesignerFormWindowInterface.findFormWindow(widget)
+        if form:
+            form.emitSelectionChanged()
+
+
+class StackedWidgetExtension(QPyDesignerContainerExtension):
+    """ Stacked widget extension """
+
+    def __init__(self, stacked, parent=None) -> None:
+        super().__init__(parent)
+        self.stacked = stacked
+
+    def addWidget(self, widget) -> None:
+        self.stacked.addWidget(widget)
+
+    def count(self):
+        return self.stacked.count()
+
+    def currentIndex(self):
+        return self.stacked.currentIndex()
+
+    def insertWidget(self, index, widget):
+        self.stacked.insertWidget(index, widget)
+
+    def remove(self, index):
+        self.stacked.removeWidget(self.stacked.widget(index))
+
+    def setCurrentIndex(self, index):
+        self.stacked.setCurrentIndex(index)
+
+    def widget(self, index):
+        return self.stacked.widget(index)
+
+
+class StackedWidgetExtensionFactory(QExtensionFactory):
+    """ Stacked widget extension factory """
+
+    widgets = []
+    IID = "org.qt-project.Qt.Designer.Container"
+
+    def createExtension(self, object, iid, parent):
+        if iid != StackedWidgetExtensionFactory.IID:
+            return None
+
+        if object.__class__.__name__ not in self.widgets:
+            return None
+
+        return StackedWidgetExtension(object, parent)
+
+    @classmethod
+    def register(cls, Plugin):
+        if Plugin.__name__ not in cls.widgets:
+            cls.widgets.append(Plugin().name())
+            Plugin.Factory = cls
+
+        return Plugin
+
+
+@StackedWidgetExtensionFactory.register
+class OpacityAniStackedWidgetPlugin(StackedWidgetPlugin, QDesignerCustomWidgetInterface):
+    """ opacity ani stacked widget plugin """
+
+    def createWidget(self, parent):
+        w = OpacityAniStackedWidget(parent)
+        w.currentChanged.connect(self.onCurrentIndexChanged)
+        return w
+
+    def icon(self):
+        return super().icon("StackPanel")
+
+    def name(self):
+        return "OpacityAniStackedWidget"
+
+
+@StackedWidgetExtensionFactory.register
+class PopUpAniStackedWidgetPlugin(StackedWidgetPlugin, QDesignerCustomWidgetInterface):
+    """ pop up ani stacked widget plugin """
+
+    def createWidget(self, parent):
+        w = PopUpAniStackedWidget(parent)
+        w.currentChanged.connect(self.onCurrentIndexChanged)
+        return w
+
+    def icon(self):
+        return super().icon("StackPanel")
+
+    def name(self):
+        return "PopUpAniStackedWidget"

--- a/plugins/date_time_plugin.py
+++ b/plugins/date_time_plugin.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+from PySide6.QtCore import Qt
+from PySide6.QtDesigner import QDesignerCustomWidgetInterface
+
+from qfluentwidgets import DatePicker, TimePicker, ZhDatePicker, AMTimePicker, CalendarPicker
+
+from plugin_base import PluginBase
+
+
+class DateTimePlugin(PluginBase):
+
+    def group(self):
+        return super().group() + ' (Date Time)'
+
+
+class CalendarPickerPlugin(DateTimePlugin, QDesignerCustomWidgetInterface):
+    """ Calendar picker plugin """
+
+    def createWidget(self, parent):
+        return CalendarPicker(parent)
+
+    def icon(self):
+        return super().icon("CalendarDatePicker")
+
+    def name(self):
+        return "CalendarPicker"
+
+
+class DatePickerPlugin(DateTimePlugin, QDesignerCustomWidgetInterface):
+    """ Date picker plugin """
+
+    def createWidget(self, parent):
+        return DatePicker(parent)
+
+    def icon(self):
+        return super().icon("DatePicker")
+
+    def name(self):
+        return "DatePicker"
+
+
+class ZhDatePickerPlugin(DateTimePlugin, QDesignerCustomWidgetInterface):
+    """ Chinese Date picker plugin """
+
+    def createWidget(self, parent):
+        return ZhDatePicker(parent)
+
+    def icon(self):
+        return super().icon("DatePicker")
+
+    def name(self):
+        return "ZhDatePicker"
+
+    def toolTip(self):
+        return "Chinese date picker"
+
+
+class TimePickerPlugin(DateTimePlugin, QDesignerCustomWidgetInterface):
+    """ Time picker plugin """
+
+    def createWidget(self, parent):
+        return TimePicker(parent)
+
+    def icon(self):
+        return super().icon("TimePicker")
+
+    def name(self):
+        return "TimePicker"
+
+    def toolTip(self):
+        return "24 hours time picker"
+
+
+class AMTimePickerPlugin(DateTimePlugin, QDesignerCustomWidgetInterface):
+    """ AM/PM time picker plugin """
+
+    def createWidget(self, parent):
+        return AMTimePicker(parent)
+
+    def icon(self):
+        return super().icon("TimePicker")
+
+    def name(self):
+        return "AMTimePicker"
+
+    def toolTip(self):
+        return "AM/PM time picker"

--- a/plugins/label_plugin.py
+++ b/plugins/label_plugin.py
@@ -1,0 +1,159 @@
+# coding: utf-8
+from PySide6.QtCore import Qt
+from PySide6.QtDesigner import QDesignerCustomWidgetInterface
+
+from qfluentwidgets import (BodyLabel, CaptionLabel, StrongBodyLabel, SubtitleLabel, TitleLabel, LargeTitleLabel,
+                            DisplayLabel, ImageLabel, AvatarWidget, HyperlinkLabel)
+
+from plugin_base import PluginBase
+
+
+class LabelPlugin(PluginBase):
+
+    def group(self):
+        return super().group() + ' (Label)'
+
+    def domXml(self):
+        return f"""
+        <widget class="{self.name()}" name="{self.name()}">
+            <property name="text">
+                <string>{self.toolTip()}</string>
+            </property>
+        </widget>
+        """
+
+
+class CaptionLabelPlugin(LabelPlugin, QDesignerCustomWidgetInterface):
+    """ Caption label plugin """
+
+    def createWidget(self, parent):
+        return CaptionLabel(parent)
+
+    def icon(self):
+        return super().icon("TextBlock")
+
+    def name(self):
+        return "CaptionLabel"
+
+
+class BodyLabelPlugin(LabelPlugin, QDesignerCustomWidgetInterface):
+    """ Body label plugin """
+
+    def createWidget(self, parent):
+        return BodyLabel(parent)
+
+    def icon(self):
+        return super().icon("TextBlock")
+
+    def name(self):
+        return "BodyLabel"
+
+
+class StrongBodyLabelPlugin(LabelPlugin, QDesignerCustomWidgetInterface):
+    """ Strong body label plugin """
+
+    def createWidget(self, parent):
+        return StrongBodyLabel(parent)
+
+    def icon(self):
+        return super().icon("TextBlock")
+
+    def name(self):
+        return "StrongBodyLabel"
+
+
+class SubtitleLabelPlugin(LabelPlugin, QDesignerCustomWidgetInterface):
+    """ Subtitle label plugin """
+
+    def createWidget(self, parent):
+        return SubtitleLabel(parent)
+
+    def icon(self):
+        return super().icon("TextBlock")
+
+    def name(self):
+        return "SubtitleLabel"
+
+
+class TitleLabelPlugin(LabelPlugin, QDesignerCustomWidgetInterface):
+    """ Title label plugin """
+
+    def createWidget(self, parent):
+        return TitleLabel(parent)
+
+    def icon(self):
+        return super().icon("TextBlock")
+
+    def name(self):
+        return "TitleLabel"
+
+
+class LargeTitleLabelPlugin(LabelPlugin, QDesignerCustomWidgetInterface):
+    """ Title label plugin """
+
+    def createWidget(self, parent):
+        return LargeTitleLabel(parent)
+
+    def icon(self):
+        return super().icon("TextBlock")
+
+    def name(self):
+        return "LargeTitleLabel"
+
+
+class DisplayLabelPlugin(LabelPlugin, QDesignerCustomWidgetInterface):
+    """ Display label plugin """
+
+    def createWidget(self, parent):
+        return DisplayLabel(parent)
+
+    def icon(self):
+        return super().icon("TextBlock")
+
+    def name(self):
+        return "DisplayLabel"
+
+
+class HyperlinkLabelPlugin(LabelPlugin, QDesignerCustomWidgetInterface):
+    """ Hyperlink label plugin """
+
+    def createWidget(self, parent):
+        return HyperlinkLabel(parent)
+
+    def icon(self):
+        return super().icon("HyperlinkButton")
+
+    def name(self):
+        return "HyperlinkLabel"
+
+
+class ImageLabelPlugin(LabelPlugin, QDesignerCustomWidgetInterface):
+    """ Image label plugin """
+
+    def createWidget(self, parent):
+        return ImageLabel(self.icon().pixmap(72, 72), parent)
+
+    def icon(self):
+        return super().icon("Image")
+
+    def name(self):
+        return "ImageLabel"
+
+    def domXml(self):
+        return f"""<widget class="{self.name()}" name="{self.name()}"></widget>"""
+
+
+class AvatarPlugin(LabelPlugin, QDesignerCustomWidgetInterface):
+    """ Avatar plugin """
+
+    def createWidget(self, parent):
+        return AvatarWidget(self.icon().pixmap(72, 72), parent)
+
+    def icon(self):
+        return super().icon("PersonPicture")
+
+    def name(self):
+        return "AvatarWidget"
+
+    def domXml(self):
+        return f"""<widget class="{self.name()}" name="{self.name()}"></widget>"""

--- a/plugins/navigation_plugin.py
+++ b/plugins/navigation_plugin.py
@@ -1,0 +1,161 @@
+# coding: utf-8
+from PySide6.QtCore import Qt
+from PySide6.QtDesigner import QDesignerCustomWidgetInterface
+
+from qfluentwidgets import (NavigationInterface, NavigationPanel, Pivot, SegmentedWidget, NavigationBar,
+                            FluentIcon, TabBar, BreadcrumbBar, SegmentedToolWidget, SegmentedToggleToolWidget)
+
+from plugin_base import PluginBase
+
+
+class NavigationPlugin(PluginBase):
+
+    def group(self):
+        return super().group() + ' (Navigation)'
+
+
+class BreadcrumbBarPlugin(NavigationPlugin, QDesignerCustomWidgetInterface):
+    """ Breadcrumb plugin """
+
+    def createWidget(self, parent):
+        w = BreadcrumbBar(parent)
+        w.addItem('Home', 'Home')
+        w.addItem('Documents', 'Documents')
+        return w
+
+    def icon(self):
+        return super().icon("BreadcrumbBar")
+
+    def name(self):
+        return "BreadcrumbBar"
+
+
+
+class NavigationInterfacePlugin(NavigationPlugin, QDesignerCustomWidgetInterface):
+    """ Navigation interface plugin """
+
+    def createWidget(self, parent):
+        return NavigationInterface(parent, True, True)
+
+    def icon(self):
+        return super().icon("NavigationView")
+
+    def name(self):
+        return "NavigationInterface"
+
+
+class NavigationPanelPlugin(NavigationPlugin, QDesignerCustomWidgetInterface):
+    """ Navigation panel plugin """
+
+    def createWidget(self, parent):
+        return NavigationPanel(parent)
+
+    def icon(self):
+        return super().icon("NavigationView")
+
+    def name(self):
+        return "NavigationPanel"
+
+
+class NavigationBarPlugin(NavigationPlugin, QDesignerCustomWidgetInterface):
+    """ Navigation bar plugin """
+
+    def createWidget(self, parent):
+        bar = NavigationBar(parent)
+        bar.addItem('item', FluentIcon.HOME, 'Home')
+        return bar
+
+    def icon(self):
+        return super().icon("NavigationView")
+
+    def name(self):
+        return "NavigationBar"
+
+
+class PivotPlugin(NavigationPlugin, QDesignerCustomWidgetInterface):
+    """ Navigation panel plugin """
+
+    def createWidget(self, parent):
+        p = Pivot(parent)
+        for i in range(1, 4):
+            p.addItem(f'Item{i}', f'Item{i}', print)
+
+        p.setCurrentItem('Item1')
+        return p
+
+    def icon(self):
+        return super().icon("Pivot")
+
+    def name(self):
+        return "Pivot"
+
+
+class SegmentedWidgetPlugin(NavigationPlugin, QDesignerCustomWidgetInterface):
+    """ Segmented widget plugin """
+
+    def createWidget(self, parent):
+        p = SegmentedWidget(parent)
+        for i in range(1, 4):
+            p.addItem(f'Item{i}', f'Item{i}', print)
+
+        p.setCurrentItem('Item1')
+        return p
+
+    def icon(self):
+        return super().icon("Pivot")
+
+    def name(self):
+        return "SegmentedWidget"
+
+
+class SegmentedToolWidgetPlugin(NavigationPlugin, QDesignerCustomWidgetInterface):
+    """ Segmented tool widget plugin """
+
+    def createWidget(self, parent):
+        p = SegmentedToolWidget(parent)
+        p.addItem(f'k1', FluentIcon.TRANSPARENT)
+        p.addItem(f'k2', FluentIcon.CHECKBOX)
+        p.addItem(f'k3', FluentIcon.CONSTRACT)
+        p.setCurrentItem('k1')
+        return p
+
+    def icon(self):
+        return super().icon("Pivot")
+
+    def name(self):
+        return "SegmentedToolWidget"
+
+
+class SegmentedToggleToolWidgetPlugin(NavigationPlugin, QDesignerCustomWidgetInterface):
+    """ Segmented tool widget plugin """
+
+    def createWidget(self, parent):
+        p = SegmentedToggleToolWidget(parent)
+        p.addItem(f'k1', FluentIcon.TRANSPARENT)
+        p.addItem(f'k2', FluentIcon.CHECKBOX)
+        p.addItem(f'k3', FluentIcon.CONSTRACT)
+        p.setCurrentItem('k1')
+        return p
+
+    def icon(self):
+        return super().icon("Pivot")
+
+    def name(self):
+        return "SegmentedToggleToolWidget"
+
+
+class TabBarPlugin(NavigationPlugin, QDesignerCustomWidgetInterface):
+    """ Tab bar plugin """
+
+    def createWidget(self, parent):
+        p = TabBar(parent)
+        for i in range(1, 4):
+            p.addTab(f'Tab {i}', f'Tab {i}', FluentIcon.BASKETBALL)
+
+        return p
+
+    def icon(self):
+        return super().icon("TabView")
+
+    def name(self):
+        return "TabBar"

--- a/plugins/plugin_base.py
+++ b/plugins/plugin_base.py
@@ -1,0 +1,56 @@
+# coding:utf-8
+import re
+
+from PySide6.QtGui import QIcon
+from PySide6.QtDesigner import QDesignerFormEditorInterface
+
+
+class PluginBase:
+
+	Factory = None
+
+	def __init__(self, parent=None):
+		super().__init__()
+		self.initialized = False
+		self.factory = None
+		self.pattern = re.compile(r'(?<!^)(?=[A-Z])')
+
+	def initialize(self, editor: QDesignerFormEditorInterface):
+		if self.initialized:
+			return
+
+		self.initialized = True
+		if not self.Factory:
+			return
+
+		manager = editor.extensionManager()
+		self.factory = self.Factory(manager)
+		manager.registerExtensions(self.factory, self.factory.IID)
+
+	def isInitialized(self):
+		return self.initialized
+
+	def icon(self, name: str):
+		return QIcon(f":/qfluentwidgets/images/controls/{name}.png")
+
+	def name(self):
+		return "PluginBase"
+
+	def group(self):
+		return "PySide6-Fluent-Widgets"
+
+	def toolTip(self):
+		name = self.pattern.sub(' ', self.name()).lower()
+		return name[0].upper() + name[1:]
+
+	def whatsThis(self):
+		return self.toolTip()
+
+	def isContainer(self):
+		return False
+
+	def domXml(self):
+		return f'<widget class="{self.name()}" name="{self.name()}"></widget>'
+
+	def includeFile(self):
+		return "qfluentwidgets"

--- a/plugins/register_widgets.py
+++ b/plugins/register_widgets.py
@@ -1,17 +1,11 @@
 from PySide6.QtDesigner import QPyDesignerCustomWidgetCollection
-import os, sys
-from pathlib import Path
-import qfluentwidgets
+import os
 
-plugins_dir = str(Path('.').absolute().joinpath('plugins'))
-sys.path.append(plugins_dir)
-print(plugins_dir)
 plugins = []
 
 def get_modules(py):
     # I don't know why, but they are nessary
     from PySide6.QtDesigner import QDesignerCustomWidgetInterface
-    # from plugin_base import PluginBase
     import inspect
 
     modules = []
@@ -24,7 +18,7 @@ def get_modules(py):
                 modules.append(obj)
     return modules
 
-for filename in os.listdir(plugins_dir):
+for filename in os.listdir('.'):
     if filename.endswith('.py') and not filename.startswith('_'):
         # print(filename)
         # plugins += get_modules(__import__(f"{filename}".replace('.py', '')))

--- a/plugins/status_info_plugin.py
+++ b/plugins/status_info_plugin.py
@@ -1,0 +1,107 @@
+# coding: utf-8
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtDesigner import QDesignerCustomWidgetInterface
+
+from qfluentwidgets import (InfoBar, ProgressBar, IndeterminateProgressBar, ProgressRing, StateToolTip, InfoBarPosition,
+                            IndeterminateProgressRing, InfoBadge, DotInfoBadge, IconInfoBadge, FluentIcon)
+
+from plugin_base import PluginBase
+
+
+class StatusInfoPlugin(PluginBase):
+
+    def group(self):
+        return super().group() + ' (Status & Info)'
+
+
+class ProgressBarPlugin(StatusInfoPlugin, QDesignerCustomWidgetInterface):
+    """ Progress bar plugin """
+
+    def createWidget(self, parent):
+        return ProgressBar(parent)
+
+    def icon(self):
+        return super().icon("ProgressBar")
+
+    def name(self):
+        return "ProgressBar"
+
+
+class IndeterminateProgressBarPlugin(StatusInfoPlugin, QDesignerCustomWidgetInterface):
+    """ Indeterminate progress bar plugin """
+
+    def createWidget(self, parent):
+        return IndeterminateProgressBar(parent)
+
+    def icon(self):
+        return super().icon("ProgressBar")
+
+    def name(self):
+        return "IndeterminateProgressBar"
+
+
+class ProgressRingPlugin(StatusInfoPlugin, QDesignerCustomWidgetInterface):
+    """ Progress ring plugin """
+
+    def createWidget(self, parent):
+        return ProgressRing(parent)
+
+    def icon(self):
+        return super().icon("ProgressRing")
+
+    def name(self):
+        return "ProgressRing"
+
+
+class IndeterminateProgressRingPlugin(StatusInfoPlugin, QDesignerCustomWidgetInterface):
+    """ Progress ring plugin """
+
+    def createWidget(self, parent):
+        return IndeterminateProgressRing(parent)
+
+    def icon(self):
+        return super().icon("ProgressRing")
+
+    def name(self):
+        return "IndeterminateProgressRing"
+
+
+
+
+class InfoBadgePlugin(StatusInfoPlugin, QDesignerCustomWidgetInterface):
+    """ Info badge plugin """
+
+    def createWidget(self, parent):
+        return InfoBadge('10', parent)
+
+    def icon(self):
+        return super().icon("InfoBadge")
+
+    def name(self):
+        return "InfoBadge"
+
+
+class DotInfoBadgePlugin(StatusInfoPlugin, QDesignerCustomWidgetInterface):
+    """ Dot info badge plugin """
+
+    def createWidget(self, parent):
+        return DotInfoBadge(parent)
+
+    def icon(self):
+        return super().icon("InfoBadge")
+
+    def name(self):
+        return "DotInfoBadge"
+
+
+class IconInfoBadgePlugin(StatusInfoPlugin, QDesignerCustomWidgetInterface):
+    """ Icon info badge plugin """
+
+    def createWidget(self, parent):
+        return IconInfoBadge.success(FluentIcon.ACCEPT_MEDIUM, parent)
+
+    def icon(self):
+        return super().icon("InfoBadge")
+
+    def name(self):
+        return "IconInfoBadge"

--- a/plugins/task_menu_factory.py
+++ b/plugins/task_menu_factory.py
@@ -1,0 +1,163 @@
+# coding: utf-8
+from typing import Type
+from PySide6 import QtWidgets
+
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QWidget
+from PySide6.QtDesigner import QPyDesignerTaskMenuExtension, QExtensionFactory, QDesignerFormWindowInterface, QDesignerCustomWidgetInterface
+
+
+from qfluentwidgets import MessageBox, LineEdit, TextEdit, CustomStyleSheet
+
+
+class EditTextDialog(MessageBox):
+
+    def __init__(self, widget: QWidget, parent=None):
+        super().__init__('Edit text', '', parent)
+        self.contentLabel.hide()
+
+        self.lineEdit = LineEdit(self.widget)
+        self.propertyName = 'text_' if widget.property('text') is None else 'text'
+        self.lineEdit.setText(widget.property(self.propertyName))
+
+        self.lineEdit.selectAll()
+        self.lineEdit.setFocus()
+        self.lineEdit.setClearButtonEnabled(True)
+        self.lineEdit.setPlaceholderText('Enter the text of button')
+
+        self.textLayout.addWidget(self.lineEdit)
+        self.widget.setFixedSize(
+            max(self.contentLabel.width(), self.titleLabel.width()) + 48,
+            self.contentLabel.y() + self.lineEdit.height() + 105
+        )
+
+
+class EditQssDialog(MessageBox):
+
+    def __init__(self, qss: str, parent=None):
+        super().__init__('Edit Style Sheet', '', parent)
+        self.contentLabel.hide()
+
+        self.textEdit = TextEdit(self.widget)
+        self.textEdit.setPlainText(qss)
+
+        self.textEdit.setFocus()
+        self.textEdit.setPlaceholderText('Enter the custom qss of widget')
+        self.textEdit.setFixedSize(500, 500)
+
+        self.textLayout.addWidget(self.textEdit)
+        self.widget.setFixedSize(
+            max(self.contentLabel.width(), self.titleLabel.width()) + 48,
+            self.contentLabel.y() + self.textEdit.height() + 105
+        )
+
+    def qss(self):
+        return self.textEdit.toPlainText()
+
+
+class TaskMenuExtensionBase(QPyDesignerTaskMenuExtension):
+    """ Task menu extension base class """
+
+    def __init__(self, widget, parent):
+        super().__init__(parent)
+        self.widget = widget
+        self.editTextAction = QAction('Edit text', None)
+        self.editTextAction.triggered.connect(self.onEditText)
+
+    def taskActions(self):
+        return [self.editTextAction]
+
+    def preferredEditAction(self) -> QAction:
+        return self.editTextAction
+
+    def onEditText(self):
+        w = EditTextDialog(self.widget, self.widget.window())
+        window = QDesignerFormWindowInterface.findFormWindow(self.widget)
+        if w.exec():
+            window.cursor().setProperty(w.propertyName, w.lineEdit.text())
+
+
+class EditTextTaskMenuExtension(TaskMenuExtensionBase):
+    """ Edit text task menu extension """
+
+    def taskActions(self):
+        return [self.editTextAction]
+
+
+class CustomStyleSheetTaskMenuExtension(QPyDesignerTaskMenuExtension):
+    """ Custom style sheet task menu extension """
+
+    def __init__(self, widget, parent):
+        super().__init__(parent)
+        self.widget = widget
+        self.customStyleSheet = CustomStyleSheet(self.widget)
+        self.lightQssAct = QAction('Edit custom qss in light mode', None)
+        self.darkQssAct = QAction('Edit custom qss in dark mode', None)
+        self.lightQssAct.triggered.connect(self.onEditLightQss)
+        self.darkQssAct.triggered.connect(self.onEditDarkQss)
+
+    def taskActions(self):
+        return [self.lightQssAct, self.darkQssAct]
+
+    def preferredEditAction(self) -> QAction:
+        return self.lightQssAct
+
+    def onEditLightQss(self):
+        w = EditQssDialog(self.customStyleSheet.lightStyleSheet(), self.widget.window())
+        if w.exec():
+            self.customStyleSheet.setLightStyleSheet(w.qss())
+
+    def onEditDarkQss(self):
+        w = EditQssDialog(self.customStyleSheet.darkStyleSheet(), self.widget.window())
+        if w.exec():
+            self.customStyleSheet.setDarkStyleSheet(w.qss())
+
+
+class EditTextIconTaskMenuExtension(TaskMenuExtensionBase):
+    """ Edit text and icon task menu extension """
+
+    def taskActions(self):
+        return [self.editTextAction, self.editIconAction]
+
+    def preferredEditAction(self):
+        return self.editTextAction
+
+
+class TaskMenuFactoryBase(QExtensionFactory):
+    """ Task menu factory base class """
+
+    widgets = []
+    Extention = QPyDesignerTaskMenuExtension
+    IID = 'org.qt-project.Qt.Designer.TaskMenu'
+
+    def createExtension(self, object, iid, parent):
+        if iid != TaskMenuFactoryBase.IID:
+            return None
+
+        if object.__class__.__name__ not in self.widgets:
+            return None
+
+        return self.Extention(object, parent)
+
+    @classmethod
+    def register(cls, Plugin: Type[QDesignerCustomWidgetInterface]):
+        if Plugin.__name__ not in cls.widgets:
+            cls.widgets.append(Plugin().name())
+            Plugin.Factory = cls
+
+        return Plugin
+
+
+class EditTextTaskMenuFactory(TaskMenuFactoryBase):
+    """ Edit text task menu factory """
+
+    Extention = CustomStyleSheetTaskMenuExtension
+    widgets = []
+
+
+class EditCustomStyleSheetTaskMenuFactory(TaskMenuFactoryBase):
+    """ Edit custom style sheet task menu factory """
+
+    widgets = []
+    Extention = CustomStyleSheetTaskMenuExtension
+

--- a/plugins/text_plugin.py
+++ b/plugins/text_plugin.py
@@ -1,0 +1,211 @@
+# coding: utf-8
+from PySide6.QtCore import Qt
+from PySide6.QtDesigner import QDesignerCustomWidgetInterface
+
+from qfluentwidgets import (SpinBox, CompactSpinBox, DoubleSpinBox, CompactDoubleSpinBox, TextEdit,
+                            TimeEdit, CompactTimeEdit, DateTimeEdit, CompactDateTimeEdit,
+                            LineEdit, PlainTextEdit, DateEdit, CompactDateEdit, SearchLineEdit,
+                            PasswordLineEdit)
+
+from plugin_base import PluginBase
+
+
+class TextPlugin(PluginBase):
+
+    def group(self):
+        return super().group() + ' (Text)'
+
+
+class LineEditPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Line edit plugin """
+
+    def createWidget(self, parent):
+        return LineEdit(parent)
+
+    def icon(self):
+        return super().icon("TextBox")
+
+    def name(self):
+        return "LineEdit"
+
+
+class SearchLineEditPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Search line edit plugin """
+
+    def createWidget(self, parent):
+        return SearchLineEdit(parent)
+
+    def icon(self):
+        return super().icon("TextBox")
+
+    def name(self):
+        return "SearchLineEdit"
+
+
+class PasswordLineEditPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Password line edit plugin """
+
+    def createWidget(self, parent):
+        return PasswordLineEdit(parent)
+
+    def icon(self):
+        return super().icon("PasswordBox")
+
+    def name(self):
+        return "PasswordLineEdit"
+
+
+class TextEditPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Text edit plugin """
+
+    def createWidget(self, parent):
+        return TextEdit(parent)
+
+    def icon(self):
+        return super().icon("RichEditBox")
+
+    def name(self):
+        return "TextEdit"
+
+
+class PlainTextEditPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Plain text edit plugin """
+
+    def createWidget(self, parent):
+        return PlainTextEdit(parent)
+
+    def icon(self):
+        return super().icon("RichEditBox")
+
+    def name(self):
+        return "PlainTextEdit"
+
+
+class DateEditPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Date edit plugin """
+
+    def createWidget(self, parent):
+        return DateEdit(parent)
+
+    def icon(self):
+        return super().icon("NumberBox")
+
+    def name(self):
+        return "DateEdit"
+
+
+class TimeEditPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Time edit plugin """
+
+    def createWidget(self, parent):
+        return TimeEdit(parent)
+
+    def icon(self):
+        return super().icon("NumberBox")
+
+    def name(self):
+        return "TimeEdit"
+
+
+class DateTimeEditPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Date time edit plugin """
+
+    def createWidget(self, parent):
+        return DateTimeEdit(parent)
+
+    def icon(self):
+        return super().icon("NumberBox")
+
+    def name(self):
+        return "DateTimeEdit"
+
+
+class SpinBoxPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Spin box plugin """
+
+    def createWidget(self, parent):
+        return SpinBox(parent)
+
+    def icon(self):
+        return super().icon("NumberBox")
+
+    def name(self):
+        return "SpinBox"
+
+
+class DoubleSpinBoxPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Double spin box plugin """
+
+    def createWidget(self, parent):
+        return DoubleSpinBox(parent)
+
+    def icon(self):
+        return super().icon("NumberBox")
+
+    def name(self):
+        return "DoubleSpinBox"
+
+
+class CompactDateEditPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Compact date edit plugin """
+
+    def createWidget(self, parent):
+        return CompactDateEdit(parent)
+
+    def icon(self):
+        return super().icon("NumberBox")
+
+    def name(self):
+        return "CompactDateEdit"
+
+
+class CompactTimeEditPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Compact time edit plugin """
+
+    def createWidget(self, parent):
+        return CompactTimeEdit(parent)
+
+    def icon(self):
+        return super().icon("NumberBox")
+
+    def name(self):
+        return "CompactTimeEdit"
+
+
+class CompactDateTimeEditPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Date time edit plugin """
+
+    def createWidget(self, parent):
+        return CompactDateTimeEdit(parent)
+
+    def icon(self):
+        return super().icon("NumberBox")
+
+    def name(self):
+        return "CompactDateTimeEdit"
+
+
+class CompactSpinBoxPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Compact spin box plugin """
+
+    def createWidget(self, parent):
+        return CompactSpinBox(parent)
+
+    def icon(self):
+        return super().icon("NumberBox")
+
+    def name(self):
+        return "CompactSpinBox"
+
+
+class CompactDoubleSpinBoxPlugin(TextPlugin, QDesignerCustomWidgetInterface):
+    """ Compact double spin box plugin """
+
+    def createWidget(self, parent):
+        return CompactDoubleSpinBox(parent)
+
+    def icon(self):
+        return super().icon("NumberBox")
+
+    def name(self):
+        return "CompactDoubleSpinBox"

--- a/plugins/toolbar_plugin.py
+++ b/plugins/toolbar_plugin.py
@@ -1,0 +1,31 @@
+# coding: utf-8
+from PySide6.QtCore import Qt
+from PySide6.QtDesigner import QDesignerCustomWidgetInterface
+
+from qfluentwidgets import CommandBar, Action, FluentIcon
+
+from plugin_base import PluginBase
+
+
+class ToolBarPlugin(PluginBase):
+
+    def group(self):
+        return super().group() + ' (ToolBar)'
+
+
+class CommandBarPlugin(ToolBarPlugin, QDesignerCustomWidgetInterface):
+    """ Command bar plugin """
+
+    def createWidget(self, parent):
+        w = CommandBar(parent)
+        w.addAction(Action(FluentIcon.SHARE, 'Share'))
+        w.addAction(Action(FluentIcon.SAVE, 'Save'))
+        w.addAction(Action(FluentIcon.DELETE, 'Delete'))
+        return w
+
+    def icon(self):
+        return super().icon("CommandBar")
+
+    def name(self):
+        return "CommandBar"
+

--- a/plugins/view_plugin.py
+++ b/plugins/view_plugin.py
@@ -1,0 +1,148 @@
+# coding: utf-8
+from PySide6.QtCore import Qt, QSize
+from PySide6.QtDesigner import QDesignerCustomWidgetInterface
+
+from qfluentwidgets import (ListWidget, ListView, TreeView, TreeWidget, TableView, TableWidget,
+                            HorizontalFlipView, VerticalFlipView, HorizontalPipsPager, VerticalPipsPager)
+
+from plugin_base import PluginBase
+
+
+class ViewPlugin(PluginBase):
+
+    def group(self):
+        return super().group() + ' (View)'
+
+
+class ListWidgetPlugin(ViewPlugin, QDesignerCustomWidgetInterface):
+    """ List widget plugin """
+
+    def createWidget(self, parent):
+        return ListWidget(parent)
+
+    def icon(self):
+        return super().icon("ListView")
+
+    def name(self):
+        return "ListWidget"
+
+
+class ListViewPlugin(ViewPlugin, QDesignerCustomWidgetInterface):
+    """ List view plugin """
+
+    def createWidget(self, parent):
+        return ListView(parent)
+
+    def icon(self):
+        return super().icon("ListView")
+
+    def name(self):
+        return "ListView"
+
+
+class TableWidgetPlugin(ViewPlugin, QDesignerCustomWidgetInterface):
+    """ Table widget plugin """
+
+    def createWidget(self, parent):
+        return TableWidget(parent)
+
+    def icon(self):
+        return super().icon("DataGrid")
+
+    def name(self):
+        return "TableWidget"
+
+
+class TableViewPlugin(ViewPlugin, QDesignerCustomWidgetInterface):
+    """ Table widget plugin """
+
+    def createWidget(self, parent):
+        return TableView(parent)
+
+    def icon(self):
+        return super().icon("DataGrid")
+
+    def name(self):
+        return "TableView"
+
+
+class TreeWidgetPlugin(ViewPlugin, QDesignerCustomWidgetInterface):
+    """ Tree widget plugin """
+
+    def createWidget(self, parent):
+        return TreeWidget(parent)
+
+    def icon(self):
+        return super().icon("TreeView")
+
+    def name(self):
+        return "TreeWidget"
+
+
+class TreeViewPlugin(ViewPlugin, QDesignerCustomWidgetInterface):
+    """ Tree view plugin """
+
+    def createWidget(self, parent):
+        return TreeView(parent)
+
+    def icon(self):
+        return super().icon("TreeView")
+
+    def name(self):
+        return "TreeView"
+
+
+class HorizontalFlipViewPlugin(ViewPlugin, QDesignerCustomWidgetInterface):
+    """ Horizontal flip view plugin """
+
+    def createWidget(self, parent):
+        return HorizontalFlipView(parent)
+
+    def icon(self):
+        return super().icon("FlipView")
+
+    def name(self):
+        return "HorizontalFlipView"
+
+
+class VerticalFlipViewPlugin(ViewPlugin, QDesignerCustomWidgetInterface):
+    """ Vertical flip view plugin """
+
+    def createWidget(self, parent):
+        return VerticalFlipView(parent)
+
+    def icon(self):
+        return super().icon("FlipView")
+
+    def name(self):
+        return "VerticalFlipView"
+
+
+class HorizontalPipsPagerPlugin(ViewPlugin, QDesignerCustomWidgetInterface):
+    """ Horizontal flip view plugin """
+
+    def createWidget(self, parent):
+        w = HorizontalPipsPager(parent)
+        w.setPageNumber(5)
+        return w
+
+    def icon(self):
+        return super().icon("PipsPager")
+
+    def name(self):
+        return "HorizontalPipsPager"
+
+
+class VerticalPipsPagerPlugin(ViewPlugin, QDesignerCustomWidgetInterface):
+    """ Vertical flip view plugin """
+
+    def createWidget(self, parent):
+        w = VerticalPipsPager(parent)
+        w.setPageNumber(5)
+        return w
+
+    def icon(self):
+        return super().icon("PipsPager")
+
+    def name(self):
+        return "VerticalPipsPager"

--- a/tools/designer.py
+++ b/tools/designer.py
@@ -1,6 +1,7 @@
-import qfluentwidgets
 import os
 from pathlib import Path
 
-print(f"cd { str(Path(__file__).parent.parent) } && export PYSIDE_DESIGNER_PLUGINS=\"./tools\" && pyside6-designer")
-os.system(f"cd { str(Path(__file__).parent.parent) } && export PYSIDE_DESIGNER_PLUGINS=\"./tools\" && pyside6-designer")
+plugin_path = Path(__file__).parent.parent.joinpath("plugins")
+os.environ["PYSIDE_DESIGNER_PLUGINS"] = str(plugin_path)
+
+os.system(f"cd { plugin_path } && pyside6-designer")

--- a/tools/designer.py
+++ b/tools/designer.py
@@ -1,0 +1,6 @@
+import qfluentwidgets
+import os
+from pathlib import Path
+
+print(f"cd { str(Path(__file__).parent.parent) } && export PYSIDE_DESIGNER_PLUGINS=\"./tools\" && pyside6-designer")
+os.system(f"cd { str(Path(__file__).parent.parent) } && export PYSIDE_DESIGNER_PLUGINS=\"./tools\" && pyside6-designer")

--- a/tools/register_widgets.py
+++ b/tools/register_widgets.py
@@ -1,0 +1,34 @@
+from PySide6.QtDesigner import QPyDesignerCustomWidgetCollection
+import os, sys
+from pathlib import Path
+import qfluentwidgets
+
+plugins_dir = str(Path('.').absolute().joinpath('plugins'))
+sys.path.append(plugins_dir)
+print(plugins_dir)
+plugins = []
+
+def get_modules(py):
+    # I don't know why, but they are nessary
+    from PySide6.QtDesigner import QDesignerCustomWidgetInterface
+    # from plugin_base import PluginBase
+    import inspect
+
+    modules = []
+    for name, obj in inspect.getmembers(py, inspect.isclass):
+        if name.endswith('Plugin'):
+            obj = obj()
+            # print(name, isinstance(obj, QDesignerCustomWidgetInterface))
+            if isinstance(obj, QDesignerCustomWidgetInterface):
+                print(f"Loading {name}")
+                modules.append(obj)
+    return modules
+
+for filename in os.listdir(plugins_dir):
+    if filename.endswith('.py') and not filename.startswith('_'):
+        # print(filename)
+        # plugins += get_modules(__import__(f"{filename}".replace('.py', '')))
+
+        py = __import__(f"{filename}".replace('.py', ''))
+        for plug in get_modules(py):
+            QPyDesignerCustomWidgetCollection.addCustomWidget(plug)


### PR DESCRIPTION
![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/116942368/62c3e612-c551-48ad-a7e9-f9209994b1c8)

## What did I do?
Modified from [PyQt5 plugins](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/tree/master/plugins).
1. First, I simply replace `PyQt5` to `PySide6`.
2. Because `PySide6` has different APIs, so I replace `QPyDesignerCustomWidgetPlugin` to `QDesignerCustomWidgetInterface`.
3. Finally, because `PySide6` uses different way to load plugins, so I wrote `register_widgets.py` to make designer load those plugins.

Here is an example shows what's the difference:
![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/116942368/c2e4328f-5c8c-47d4-98b1-d3d21430b21f)

(For more information, see [here](https://doc.qt.io/qtforpython-6/tutorials/basictutorial/uifiles.html#designer-custom-widgets))

## How to use?
Try to run `PyQt-Fluent-Widgets/tools/designer.py`, or you can set the environment by yourself.
1. Change the dir to 'PyQt-Fluent-Widgets'
2. Set the environment `PYSIDE_DESIGNER_PLUGINS` to the folder path of `register_widgets.py`. (Like `export PYSIDE_DESIGNER_PLUGINS="./tools"`)
3. Run `pyside6-designer`

(I'm new at open-source community. If there is any problem, just tell me. :cat:)