### PR TITLE
Add sizeHint to system tray menu to solve issue #698.

### DIFF
--- a/qfluentwidgets/components/widgets/menu.py
+++ b/qfluentwidgets/components/widgets/menu.py
@@ -1202,17 +1202,19 @@ class CheckableMenu(RoundMenu):
 class SystemTrayMenu(RoundMenu):
     """ System tray menu """
 
-    def showEvent(self, e):
-        super().showEvent(e)
-        self.adjustPosition()
+    def sizeHint(self) -> QSize:
+        m = self.layout().contentsMargins()
+        s = self.layout().sizeHint()
+        return QSize(s.width() - m.right() + 5, s.height() - m.bottom())
 
 
 class CheckableSystemTrayMenu(CheckableMenu):
     """ Checkable system tray menu """
 
-    def showEvent(self, e):
-        super().showEvent(e)
-        self.adjustPosition()
+    def sizeHint(self) -> QSize:
+        m = self.layout().contentsMargins()
+        s = self.layout().sizeHint()
+        return QSize(s.width() - m.right() + 5, s.height() - m.bottom())
 
 
 class LabelContextMenu(RoundMenu):


### PR DESCRIPTION
### Using sizeHint instead of adjustPosition in SystemTrayMenu and CheckableSystemTrayMenu.
1. Qt will using `QMenu::popup()` to display system tray menu, and the `QMenu::popup()` will use `QMenuPrivate::popup()` to display the menu, which will adjust the menu position and cause our `adjustPosition()` calculation result to be incorrect.
2. Also `QMenu::popup()` is not a virtual function, we cannot override it.

So just use `sizeHint` to tell `QMenuPrivate` the real size of our menu, Qt will help us calculate the menu position and display it.