### PR TITLE
修复PickerBase无法在clearColumns中移除旧按钮导致的新旧按钮重叠(#801)

### DIFF
--- a/qfluentwidgets/components/date_time/picker_base.py
+++ b/qfluentwidgets/components/date_time/picker_base.py
@@ -322,6 +322,9 @@ class PickerBase(QPushButton):
         while self.columns:
             btn = self.columns.pop()
             self.hBoxLayout.removeWidget(btn)
+            # The parent of btn should be explicitly set to None to remove references from its parent.
+            # Otherwise, GC will not collect and remove it until the end of it parent life-cycle
+            btn.setParent(None)
             btn.deleteLater()
 
     def enterEvent(self, e):


### PR DESCRIPTION
PickerBase的clearColumns中使用deleteLater尝试删除按钮，但是由于按钮的父对象仍持有该按钮的引用，导致垃圾回收无法回收按钮。
补丁通过设置父对象为空消除父对象对他的引用来及时删除按钮，只调用deleteLater会产生悬空的引用，可能会导致以下错误：RuntimeError: wrapped C/C++ object of type MyLabel has been deleted。