### PR TITLE
修复了CalendarView控件时延过长的问题

### DIFF
--- a/qfluentwidgets/components/date_time/calendar_picker.py
+++ b/qfluentwidgets/components/date_time/calendar_picker.py
@@ -23,7 +23,12 @@ class CalendarPicker(QPushButton):
         self.setText(self.tr('Pick a date'))
         FluentStyleSheet.CALENDAR_PICKER.apply(self)
 
+        # Initialize CalendarView as a member variable
+        self.calendar_view = CalendarView(self.window())
+        self.calendar_view.dateChanged.connect(self._onDateChanged)
+
         self.clicked.connect(self._showCalendarView)
+        self.parent().destroyed.connect(self._onDelCalendarView)
 
     def getDate(self):
         return self._date
@@ -37,19 +42,16 @@ class CalendarPicker(QPushButton):
 
     def setDateFormat(self, format: Union[Qt.DateFormat, str]):
         self._dateFormat = format
-        if self.date.isValid():
-            self.setText(self.date.toString(self.dateFormat))
+        if self._date.isValid():
+            self.setText(self._date.toString(self._dateFormat))
 
     def _showCalendarView(self):
-        view = CalendarView(self.window())
-        view.dateChanged.connect(self._onDateChanged)
+        if self._date.isValid():
+            self.calendar_view.setDate(self._date)
 
-        if self.date.isValid():
-            view.setDate(self.date)
-
-        x = int(self.width()/2 - view.sizeHint().width()/2)
+        x = int(self.width()/2 - self.calendar_view.sizeHint().width()/2)
         y = self.height()
-        view.exec(self.mapToGlobal(QPoint(x, y)))
+        self.calendar_view.exec(self.mapToGlobal(QPoint(x, y)))
 
     def _onDateChanged(self, date: QDate):
         self._date = QDate(date)
@@ -59,6 +61,12 @@ class CalendarPicker(QPushButton):
         self.update()
 
         self.dateChanged.emit(date)
+
+    def _onDelCalendarView(self):
+        if self.calendar_view is not None:
+            self.calendar_view.deleteLater()
+            self.calendar_view = None
+
 
     def paintEvent(self, e):
         super().paintEvent(e)

--- a/qfluentwidgets/components/date_time/calendar_view.py
+++ b/qfluentwidgets/components/date_time/calendar_view.py
@@ -442,26 +442,21 @@ class DayScrollView(ScrollViewBase):
     def _initItems(self):
         startDate = QDate(self.minYear, 1, 1)
         endDate = QDate(self.maxYear, 12, 31)
-        currentDate = startDate
+        totalDays = endDate.toJulianDay() - startDate.toJulianDay()
 
         # add placeholder
-        bias = currentDate.dayOfWeek() - 1
-        for i in range(bias):
-            item = QListWidgetItem(self)
-            item.setFlags(Qt.NoItemFlags)
-            self.addItem(item)
+        item = QListWidgetItem(self)
+        item.setFlags(Qt.NoItemFlags)
+        self.addItem(item)
 
         # add day items
-        items, dates = [], []
-        while currentDate <= endDate:
-            items.append(str(currentDate.day()))
-            dates.append(QDate(currentDate))
-            currentDate = currentDate.addDays(1)
+        dates = [startDate.addDays(i) for i in range(totalDays + 1)]
+        items = [str(date.day()) for date in dates]
 
         self.addItems(items)
-        for i in range(bias, self.count()):
+        for i in range(self.count()):
             item = self.item(i)
-            item.setData(Qt.UserRole, dates[i-bias])
+            item.setData(Qt.UserRole, dates[i-1]) 
             item.setSizeHint(self.gridSize())
 
         self.delegate.setCurrentIndex(self.model().index(self._dateToRow(self.currentDate)))
@@ -553,7 +548,7 @@ class CalendarView(QWidget):
         self.setWindowFlags(Qt.Popup | Qt.FramelessWindowHint |
                             Qt.NoDropShadowWindowHint)
         self.setAttribute(Qt.WA_TranslucentBackground)
-        self.setAttribute(Qt.WA_DeleteOnClose, True)
+        self.setAttribute(Qt.WA_DeleteOnClose, False)
 
         self.stackedWidget.addWidget(self.dayView)
         self.stackedWidget.addWidget(self.monthView)


### PR DESCRIPTION
修改了两处，优化一处：

修改CalendarPicker类中通过信号槽触发CalendarView实例化替换成通过__init__部分避免多次更新带来触发延迟

修改CalendarView中的self.setAttribute(Qt.WA_DeleteOnClose, Ture)设置为False，并在CalendarPicker实现destroyed信号槽与_onDelCalendarView函数，使其跟随父类销毁避免内存泄漏

优化DayScrollView中initItems函数，降低最高0.3秒左右的计算延迟


