### PR TITLE
增强 `TableWidget` 和 `TableView` 在大数据量体验

### DIFF
--- a/qfluentwidgets/components/widgets/table_view.py
+++ b/qfluentwidgets/components/widgets/table_view.py
@@ -201,7 +201,13 @@ class TableBase:
 
     def showEvent(self, e):
         QTableView.showEvent(self, e)
-        self.resizeRowsToContents()
+        totalRows = self.rowCount() if hasattr(self, "rowCount") else self.model().rowCount(0)
+
+        if totalRows <= 500:
+            self.resizeRowsToContents()
+        else:
+            self._resizeVisibleRowsToContents()
+            self.verticalScrollBar().valueChanged.connect(self._resizeVisibleRowsToContents)
 
     def setBorderVisible(self, isVisible: bool):
         """ set the visibility of border """
@@ -212,6 +218,13 @@ class TableBase:
         """ set the radius of border """
         qss = f"QTableView{{border-radius: {radius}px}}"
         setCustomStyleSheet(self, qss, qss)
+
+    def _resizeVisibleRowsToContents(self):
+        index = self.indexAt(self.rect().topLeft()).row()
+        end = self.indexAt(self.rect().bottomLeft()).row()
+
+        for row in range(index, end + 1):
+            self.resizeRowToContents(row)
 
     def _setHoverRow(self, row: int):
         """ set hovered row """
@@ -234,6 +247,7 @@ class TableBase:
     def resizeEvent(self, e):
         QTableView.resizeEvent(self, e)
         self.viewport().update()
+        self._resizeVisibleRowsToContents()
 
     def keyPressEvent(self, e: QKeyEvent):
         QTableView.keyPressEvent(self, e)

--- a/qfluentwidgets/components/widgets/table_view.py
+++ b/qfluentwidgets/components/widgets/table_view.py
@@ -2,10 +2,9 @@
 from typing import List, Union
 
 from PyQt5.QtCore import Qt, QMargins, QModelIndex, QItemSelectionModel, pyqtProperty, QRectF
-from PyQt5.QtGui import QPainter, QColor, QKeyEvent, QPalette, QBrush
+from PyQt5.QtGui import QPainter, QColor, QKeyEvent, QPalette
 from PyQt5.QtWidgets import (QStyledItemDelegate, QApplication, QStyleOptionViewItem,
-                             QTableView, QTableWidget, QWidget, QTableWidgetItem, QStyle,
-                             QStyleOptionButton)
+                             QTableView, QTableWidget, QWidget, QTableWidgetItem)
 
 from .check_box import CheckBoxIcon
 from ...common.font import getFont


### PR DESCRIPTION
## 动机
#805 指出在数据量（实际也不大）过大时，切换 Widget 会导致明显卡顿。
## 原因
在 `TableBase` 这个 Minxi Base 类中，对 `TableWidget` 和 `TableView` 在显示的时候做了 `resizeRowsToContents` 方法调整，这是一个耗时操作，导致了阻塞卡顿。
## 解决方案
可以在数据量大于 500 的时候只对可视区域进行调整，这样大幅度改善体验，下面是前后对比，视频一中 2000 条数据，其中一个重写了 `showEvent` 跳过了 `resizeRowsToContents` 方法，另一个则是组件库实现，可以看到在切换的时候出现了非常明显的卡顿和阻塞，视频二完全消除了阻塞，在滑动和大小调整的时候都流畅，同时测试了  `TableWidget` 和 `TableView`  符合预期。

https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/d59bae9c-f342-4360-b04a-8633a463e049

https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/8cf058ef-c005-4b4e-95f9-78ddbb543554


