### PR TITLE
Fix #818: Disable IME for PasswordLineEdit

### DIFF
--- a/qfluentwidgets/components/widgets/line_edit.py
+++ b/qfluentwidgets/components/widgets/line_edit.py
@@ -426,4 +426,11 @@ class PasswordLineEdit(LineEdit):
 
         return super().eventFilter(obj, e)
 
+    def inputMethodQuery(self, query: Qt.InputMethodQuery):
+        # Disable IME for PasswordLineEdit
+        if query == Qt.InputMethodQuery.ImEnabled:
+            return False
+        else:
+            return super().inputMethodQuery(query)
+
     passwordVisible = pyqtProperty(bool, isPasswordVisible, setPasswordVisible)


### PR DESCRIPTION
### Fix #818: Disable IME for PasswordLineEdit
Use QWidget::inputMethodQuery to disable IME in password LineEdit. Always return False when query Qt::ImEnabled.
