### PR TITLE
添加自定义侧边导航栏字体颜色的支持(#826)

### DIFF
--- a/qfluentwidgets/components/navigation/navigation_widget.py
+++ b/qfluentwidgets/components/navigation/navigation_widget.py
@@ -33,6 +33,10 @@ class NavigationWidget(QWidget):
         self.treeParent = None
         self.nodeDepth = 0
         self.setFixedSize(40, 36)
+        # Custom font color
+        self._light_mode_color = QColor(0, 0, 0)
+        self._dark_mode_color = QColor(255, 255, 255)
+
 
     def enterEvent(self, e):
         self.isEnter = True
@@ -84,7 +88,24 @@ class NavigationWidget(QWidget):
         self.isSelected = isSelected
         self.update()
         self.selectedChanged.emit(isSelected)
+    
+    # About custom font color, default behavior
+    def getLightColor(self) -> QColor:
+        return self._light_mode_color
+    
+    def getDarkColor(self) -> QColor:
+        return self._dark_mode_color
+    
+    def setLightColor(self, c: QColor):
+        self._light_mode_color = c
+        self.update()
+    
+    def setDarkColor(self, c: QColor):
+        self._dark_mode_color = c
+        self.update()
 
+    lightColor = pyqtProperty(QColor, getLightColor, setLightColor, user=True)
+    darkColor = pyqtProperty(QColor, getDarkColor, setDarkColor, user=True)
 
 class NavigationPushButton(NavigationWidget):
     """ Navigation push button """
@@ -161,7 +182,7 @@ class NavigationPushButton(NavigationWidget):
             return
 
         painter.setFont(self.font())
-        painter.setPen(QColor(c, c, c))
+        painter.setPen(self._dark_mode_color if isDarkTheme() else self._light_mode_color)
 
         left = 44 + pl if not self.icon().isNull() else pl + 16
         painter.drawText(QRectF(left, 0, self.width()-13-left-pr, self.height()), Qt.AlignVCenter, self.text())
@@ -468,6 +489,23 @@ class NavigationTreeWidget(NavigationTreeWidgetBase):
         if not clickArrow or self.isCompacted:
             self.clicked.emit(triggerByUser)
 
+    def getLightColor(self) -> QColor:
+        return self.itemWidget._light_mode_color
+    
+    def getDarkColor(self) -> QColor:
+        return self.itemWidget._dark_mode_color
+    
+    def setLightColor(self, c: QColor):
+        self.itemWidget._light_mode_color = c
+        self.update()
+    
+    def setDarkColor(self, c: QColor):
+        self.itemWidget._dark_mode_color = c
+        self.update()
+    
+    lightColor = pyqtProperty(QColor, getLightColor, setLightColor, user=True)
+    darkColor = pyqtProperty(QColor, getDarkColor, setDarkColor, user=True)
+
 
 class NavigationAvatarWidget(NavigationWidget):
     """ Avatar widget """
@@ -475,6 +513,8 @@ class NavigationAvatarWidget(NavigationWidget):
     def __init__(self, name: str, avatar: Union[str, QPixmap, QImage], parent=None):
         super().__init__(isSelectable=False, parent=parent)
         self.name = name
+        self._light_mode_color = QColor(0, 0, 0)
+        self._dark_mode_color = QColor(255, 255, 255)
         self.setAvatar(avatar)
         setFont(self)
 
@@ -513,7 +553,7 @@ class NavigationAvatarWidget(NavigationWidget):
         painter.translate(-8, -6)
 
         if not self.isCompacted:
-            painter.setPen(Qt.white if isDarkTheme() else Qt.black)
+            painter.setPen(self._dark_mode_color if isDarkTheme() else self._light_mode_color)
             painter.setFont(self.font())
             painter.drawText(QRect(44, 0, 255, 36), Qt.AlignVCenter, self.name)
 


### PR DESCRIPTION
支持自定义侧边导航栏的控件的文字颜色
通过设置`lightColor`和`darkColor`两个属性即可设置字体颜色，支持使用QSS样式设置。
示例代码：
```Python
from PyQt5.QtGui import QColor, QImage
from PyQt5.QtCore import Qt, QSize
from PyQt5.QtWidgets import QApplication, QWidget, QLabel, QVBoxLayout
from qfluentwidgets import FluentWindow, qconfig, Theme, isDarkTheme, QConfig, setTheme, NavigationAvatarWidget, NavigationItemPosition, SubtitleLabel
from qfluentwidgets import FluentIcon as FIF
import base64

img = QImage(QSize(32, 32), QImage.Format.Format_RGB888)
img.fill(Qt.GlobalColor.white)


class Widget(QWidget):
    def __init__(self, name: str, parent: QWidget | None = None):
        super().__init__(parent=parent)
        self.setObjectName(name)
        v = QVBoxLayout(self)
        self.l = SubtitleLabel(name, self)
        v.addWidget(self.l, 0, Qt.AlignmentFlag.AlignCenter)


COLORS = [
    (255, 0, 0),
    (255, 165, 0),
    (255, 255, 0),
    (0, 255, 0),
    (0, 127, 255),
    (0, 0, 255),
    (139, 0, 255)
]


class Demo(FluentWindow):
    def __init__(self):
        super().__init__()
        self.resize(800, 600)
        self.widgets = []

        for i, c in enumerate(COLORS):
            w = Widget(f'Widget_{i}', self)
            self.widgets.append(w)

            self.addSubInterface(w, FIF.HOME, f'Widget {i}')

            # You can use property `lightColor` and `darkColor` to modify the font color of navigation widget
            nav_widget = self.navigationInterface.widget(w.objectName())
            nav_widget.lightColor = QColor(*c)
            nav_widget.darkColor = QColor(*map(lambda x: 255-x, c))

        self.navigationInterface.addSeparator()

        # Also you can use style sheet to modify the font color
        # Use `qproperty-lightColor` and `qproperty-darkColor` to set custom font color
        self.avatar = NavigationAvatarWidget(
            "test",
            img,
            self
        )
        self.avatar.setStyleSheet(
            r"""
            NavigationAvatarWidget {
                qproperty-lightColor: #66ccff;
                qproperty-darkColor: #66ccff;
            }
            """
        )
        self.navigationInterface.addWidget(
            "avatar",
            self.avatar,
            position=NavigationItemPosition.BOTTOM
        )
        self.navigationInterface.addSeparator()

        # Add button to switch theme
        self.navigationInterface.addItem(
            "switch_bright_dark",
            FIF.FLAG,
            "Switch Bright/Dark",
            onClick=self.switch,
            selectable=False
        )

    def switch(self):
        setTheme(Theme.LIGHT if isDarkTheme() else Theme.DARK)


if __name__ == "__main__":
    app = QApplication([])
    w = Demo()
    w.show()
    app.exec()

```
