### PR TITLE
修复 `NavigationTreeWidget` 在 `NavigationItemPosition.BOTTOM` 下的位置问题

### DIFF
--- a/qfluentwidgets/components/navigation/navigation_widget.py
+++ b/qfluentwidgets/components/navigation/navigation_widget.py
@@ -1,5 +1,5 @@
 # coding:utf-8
-from typing import Union
+from typing import Union, List
 
 from PyQt5.QtCore import (Qt, pyqtSignal, QRect, QRectF, QPropertyAnimation, pyqtProperty, QMargins,
                           QEasingCurve, QPoint, QEvent)


### PR DESCRIPTION
## 动机
当 `addSubInterface` 方法在 `NavigationItemPosition.BOTTOM` 添加一个多级菜单后，在展开后无法回到正确位置
## 原因
在 `geometry` 动画后，父布局 `invalidate`
## 解决方案
在动画结束后触发父布局 `invalidate` 重新布局
## 修复前后效果

https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/b0e14a66-e21e-49dd-8a64-9ea5bd37302d

https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/4585440/a140129f-6876-47db-b8d4-50ff36b892c6


