### PR TITLE
修复了多次点击二级菜单后菜单位置异常 (#792, #844)

### DIFF
--- a/qfluentwidgets/components/widgets/menu.py
+++ b/qfluentwidgets/components/widgets/menu.py
@@ -208,7 +208,8 @@ class MenuActionListWidget(QListWidget):
 
         # adjust the height of viewport
         w, h = MenuAnimationManager.make(self, aniType).availableViewSize(pos)
-        self.viewport().adjustSize()
+        r = self.viewport().childrenRect()
+        self.viewport().resize(r.size())
 
         # adjust the height of list widget
         m = self.viewportMargins()


### PR DESCRIPTION
在 #792 , #844 中均报告子菜单在多次重复打开后位置异常，具体原理见 #792 中解释，补丁通过计算所有子项目的大小而非使用adjustSize来避免控件大小一直增大