### PR TITLE
Fix: BreadcrumbBar popItem method crash (#850)

### DIFF
--- a/qfluentwidgets/components/navigation/breadcrumb.py
+++ b/qfluentwidgets/components/navigation/breadcrumb.py
@@ -246,15 +246,15 @@ class BreadcrumbBar(QWidget):
         """ pop trailing item """
         if not self.items:
             return
-            
-        item = self.items.pop()
-        self.itemMap.pop(item.routeKey)
-        item.deleteLater()
 
-        if self.currentIndex() >= item.index:
+        if self.count() >= 2:
             self.setCurrentIndex(self.currentIndex() - 1)
+        else:
+            self.clear()
 
-        self.updateGeometry()
+    def count(self):
+        """ Returns the number of items """
+        return len(self.items)
 
     def updateGeometry(self):
         if not self.items:

--- a/qfluentwidgets/components/navigation/breadcrumb.py
+++ b/qfluentwidgets/components/navigation/breadcrumb.py
@@ -194,7 +194,7 @@ class BreadcrumbBar(QWidget):
         if not 0 <= index < len(self.items) or index == self.currentIndex():
             return
 
-        if self.currentIndex() >= 0:
+        if 0<= self.currentIndex() < len(self.items):
             self.currentItem().setSelected(False)
 
         self._currentIndex = index
@@ -244,6 +244,9 @@ class BreadcrumbBar(QWidget):
 
     def popItem(self):
         """ pop trailing item """
+        if not self.items:
+            return
+            
         item = self.items.pop()
         self.itemMap.pop(item.routeKey)
         item.deleteLater()


### PR DESCRIPTION
Fix: BreadcrumbBar popItem method crash (#850 )
Add conditions, when deleting the last item, it will not cause a crash
Also popItem will do nothing with empty item list