### PR TITLE
修复Config类成员修改后无法保存到config.json的问题

### DIFF
--- a/qfluentwidgets/common/config.py
+++ b/qfluentwidgets/common/config.py
@@ -321,8 +321,8 @@ class QConfig(QObject):
     def toDict(self, serialize=True):
         """ convert config items to `dict` """
         items = {}
-        for name in dir(self._cfg.__class__):
-            item = getattr(self._cfg.__class__, name)
+        for name in dir(self._cfg):
+            item = getattr(self._cfg, name)
             if not isinstance(item, ConfigItem):
                 continue
 


### PR DESCRIPTION
## 问题背景
在使用串口时，由于经常要插拔串口，导致串口数量总是不固定
在这个背景下，我需要使用ComboBoxSettingCard，并在下框被点击时重新获取所有串口
<img width="832" alt="屏幕截图 2024-05-04 005655" src="https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/133895541/2a55b453-6b00-4f04-b31e-e57ef4104876">


## 业务代码
```
def __refreshSerialPort(self):
     if refreshSerialPort():  # 串口数量变化时返回true， #以下代码基本上是ComboBoxSettingCard中__init__的逻辑
         self.COMCard.configItem=cfg.port #COMCard是ComboBoxSettingCard类的对象
         self.COMCard.comboBox.clear() 

         self.COMCard.optionToText={o: t for o, t in zip(self.COMCard.configItem.options, cfg.portList)}
         for text, option in zip(cfg.portList, self.COMCard.configItem.options):
              self.COMCard.comboBox.addItem(text, userData=option)

         self.COMCard.comboBox.setCurrentText(self.COMCard.optionToText[cfg.get(cfg.port)])
         self.COMCard.comboBox.currentIndexChanged.connect(self.COMCard._onCurrentIndexChanged)
         self.COMCard.configItem.valueChanged.connect(self.COMCard.setValue)

def refreshSerialPort():
    cfg.availablPorts = QSerialPortInfo.availablePorts()
    portList = [port.portName() for port in cfg.availablPorts]
    if portList != cfg.portList:
        cfg.portList = portList
        cfg.port = OptionsConfigItem("Serial", "COM", "COM3", OptionsValidator(cfg.portList))
        return True
    else:
        return False
```

## 问题描述
当串口数量变化且用以上代码刷新后，之后再当`COMCard`下拉框选中的值改变时，不能将值保存到`config.json`中

##原因分析
- 刷新时调用`cfg.port = OptionsConfigItem("Serial", "COM", "COM3", OptionsValidator(cfg.portList))`，为`cfg.port`重新赋值
- 保存为`config.json`时调用了`qfluentwidgets\common\config.py`中`QConfig`类的`toDict`方法，其中用以下代码读取类成员的值
```
for name in dir(self._cfg.__class__):
            item = getattr(self._cfg.__class__, name)
            if not isinstance(item, ConfigItem):
                continue
```
- 关键字`.__class__`导致读取类成员的值时，读到的是cfg.port重新赋值之前的值，原因我不知道

## 解决方法
去掉`.__class__`
去掉后功能正常，但暂不清楚是否有其他影响