### PR TITLE
Make InfoBadge transparent for mouse event

### DIFF
--- a/qfluentwidgets/components/widgets/info_badge.py
+++ b/qfluentwidgets/components/widgets/info_badge.py
@@ -54,6 +54,7 @@ class InfoBadge(QLabel):
 
         setFont(self, 11)
         self.setAttribute(Qt.WA_TranslucentBackground)
+        self.setAttribute(Qt.WA_TransparentForMouseEvents)
         self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
         FluentStyleSheet.INFO_BADGE.apply(self)
 


### PR DESCRIPTION
Fix #870 , add WA_TransparentForMouseEvents attr for InfoBadge to pass through mouse event.