### PR TITLE
`SettingCard` 新增 `setIconSize` 方法

### DIFF
--- a/qfluentwidgets/components/settings/setting_card.py
+++ b/qfluentwidgets/components/settings/setting_card.py
@@ -96,6 +96,10 @@ class SettingCard(QFrame):
         """ set the value of config item """
         pass
 
+    def setIconSize(self, width: int, height: int):
+        """ set the icon fixed size """
+        self.iconLabel.setFixedSize(width, height)
+
     def paintEvent(self, e):
         painter = QPainter(self)
         painter.setRenderHints(QPainter.Antialiasing)


### PR DESCRIPTION
在某些情况下默认大小过小，新增方法允许自定义图标大小