### PR TITLE
setColumnCount 的bug修复

### DIFF
--- a/qfluentwidgets/components/widgets/tree_view.py
+++ b/qfluentwidgets/components/widgets/tree_view.py
@@ -1,7 +1,8 @@
 # coding:utf-8
 from PyQt5.QtCore import Qt, QSize, QRectF, QModelIndex
 from PyQt5.QtGui import QPainter, QColor, QPalette
-from PyQt5.QtWidgets import QTreeWidget, QStyledItemDelegate, QStyle, QTreeView, QApplication, QStyleOptionViewItem
+from PyQt5.QtWidgets import QTreeWidget, QStyledItemDelegate, QStyle, QTreeView, QApplication, QStyleOptionViewItem, \
+    QAbstractItemView
 
 from ...common.style_sheet import FluentStyleSheet, themeColor, isDarkTheme, setCustomStyleSheet
 from ...common.font import getFont
@@ -123,6 +124,10 @@ class TreeWidget(QTreeWidget, TreeViewBase):
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
+
+    def setColumnCount(self, columns: int):
+        super().setColumnCount(columns)
+        self.setVerticalScrollMode(QAbstractItemView.ScrollPerItem)
 
 
 class TreeView(QTreeView, TreeViewBase):


### PR DESCRIPTION
我在对 https://github.com/zhiyiYo/PyQt-Fluent-Widgets/issues/823 中提到的选项框错误渲染的bug进行了修复

![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/74223784/9816327c-3da0-40d6-804c-df346f5d8342)

重写了setColumnCount方法，让横向堆叠tree-widget时不会以垂直的形式渲染