### PR TITLE
fix:修复README中多余的小标签下划线

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,14 @@
   A fluent design widgets library based on PyQt5
 </p>
 
-<p align="center">
-  <a href="https://pypi.org/project/PyQt-Fluent-Widgets" target="_blank">
-    <img src="https://img.shields.io/pypi/v/pyqt-fluent-widgets?color=%2334D058&label=Version" alt="Version">
-  </a>
+<div align="center">
 
-  <a style="text-decoration:none">
-    <img src="https://static.pepy.tech/personalized-badge/pyqt-fluent-widgets?period=total&units=international_system&left_color=grey&right_color=brightgreen&left_text=Downloads" alt="Download"/>
-  </a>
+[![Version](https://img.shields.io/pypi/v/pyqt-fluent-widgets?color=%2334D058&label=Version)](https://pypi.org/project/PyQt-Fluent-Widgets)
+[![Download](https://static.pepy.tech/personalized-badge/pyqt-fluent-widgets?period=total&units=international_system&left_color=grey&right_color=brightgreen&left_text=Downloads)]()
+[![GPLv3](https://img.shields.io/badge/License-GPLv3-blue?color=#4ec820)](LICENSE)
+[![Platform Win32 | Linux | macOS](https://img.shields.io/badge/Platform-Win32%20|%20Linux%20|%20macOS-blue?color=#4ec820)]()
 
-  <a style="text-decoration:none">
-    <img src="https://img.shields.io/badge/License-GPLv3-blue?color=#4ec820" alt="GPLv3"/>
-  </a>
-
-  <a style="text-decoration:none">
-    <img src="https://img.shields.io/badge/Platform-Win32%20|%20Linux%20|%20macOS-blue?color=#4ec820" alt="Platform Win32 | Linux | macOS"/>
-  </a>
-</p>
+</div>
 
 <p align="center">
 English | <a href="docs/README_zh.md">简体中文</a> | <a href="https://qfluentwidgets.com/">官网</a>

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -8,23 +8,15 @@
   基于 PyQt5 的 Fluent Design 风格组件库
 </p>
 
-<p align="center">
-  <a href="https://pypi.org/project/PyQt-Fluent-Widgets" target="_blank">
-    <img src="https://img.shields.io/pypi/v/pyqt-fluent-widgets?color=%2334D058&label=Version" alt="Version">
-  </a>
 
-  <a style="text-decoration:none">
-    <img src="https://static.pepy.tech/personalized-badge/pyqt-fluent-widgets?period=total&units=international_system&left_color=grey&right_color=brightgreen&left_text=Downloads" alt="Download"/>
-  </a>
+<div align="center">
 
-  <a style="text-decoration:none">
-    <img src="https://img.shields.io/badge/License-GPLv3-blue?color=#4ec820" alt="GPLv3"/>
-  </a>
+[![Version](https://img.shields.io/pypi/v/pyqt-fluent-widgets?color=%2334D058&label=Version)](https://pypi.org/project/PyQt-Fluent-Widgets)
+[![Download](https://static.pepy.tech/personalized-badge/pyqt-fluent-widgets?period=total&units=international_system&left_color=grey&right_color=brightgreen&left_text=Downloads)]()
+[![GPLv3](https://img.shields.io/badge/License-GPLv3-blue?color=#4ec820)](LICENSE)
+[![Platform Win32 | Linux | macOS](https://img.shields.io/badge/Platform-Win32%20|%20Linux%20|%20macOS-blue?color=#4ec820)]()
 
-  <a style="text-decoration:none">
-    <img src="https://img.shields.io/badge/Platform-Win32%20|%20Linux%20|%20macOS-blue?color=#4ec820" alt="Platform Win32 | Linux | macOS"/>
-  </a>
-</p>
+</div>
 
 <p align="center">
 <a href="../README.md">English</a> | 简体中文 | <a href="https://qfluentwidgets.com/">官方网站</a>


### PR DESCRIPTION
由于网页端的特性，在线浏览README时徽章标签存在多余下划线的问题。此PR将HTML的<a>标签替换为Markdown风格的链接，以提高文档的美观度。

修复前：

![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/60952883/59fa0ac4-2554-4212-a024-71570e2b7165)

修复后：

![image](https://github.com/zhiyiYo/PyQt-Fluent-Widgets/assets/60952883/0e786370-43e3-4180-822f-1560ed9ac378)

