### PR TITLE
Update line_edit.py - Adding new focus change Signals

### DIFF
--- a/qfluentwidgets/components/widgets/line_edit.py
+++ b/qfluentwidgets/components/widgets/line_edit.py
@@ -56,7 +56,10 @@ class LineEditButton(QToolButton):
 
 class LineEdit(QLineEdit):
     """ Line edit """
-
+  
+    focusLost: Signal = Signal()
+    focusRecieved: Signal = Signal()
+  
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self._isClearButtonEnabled = False
@@ -100,11 +103,13 @@ class LineEdit(QLineEdit):
     def focusOutEvent(self, e):
         super().focusOutEvent(e)
         self.clearButton.hide()
+        self.focusLost.emit()
 
     def focusInEvent(self, e):
         super().focusInEvent(e)
         if self.isClearButtonEnabled():
             self.clearButton.setVisible(bool(self.text()))
+        self.focusRecieved.emit()
 
     def __onTextChanged(self, text):
         """ text changed slot """

--- a/qfluentwidgets/components/widgets/line_edit.py
+++ b/qfluentwidgets/components/widgets/line_edit.py
@@ -58,7 +58,7 @@ class LineEdit(QLineEdit):
     """ Line edit """
   
     focusLost: Signal = Signal()
-    focusRecieved: Signal = Signal()
+    focusReceived: Signal = Signal()
   
     def __init__(self, parent=None):
         super().__init__(parent=parent)
@@ -109,7 +109,7 @@ class LineEdit(QLineEdit):
         super().focusInEvent(e)
         if self.isClearButtonEnabled():
             self.clearButton.setVisible(bool(self.text()))
-        self.focusRecieved.emit()
+        self.focusReceived.emit()
 
     def __onTextChanged(self, text):
         """ text changed slot """


### PR DESCRIPTION
Added the following signals:
- focusReceived
- focusLost

This is useful because it provides an easy way to detect when the user has clicked on LineEdit. For example, this could be used to show and hide a confirm button.