### PR TITLE
Workaround for a stack overflow caused by InfoBarManager

### DIFF
--- a/qfluentwidgets/components/widgets/info_bar.py
+++ b/qfluentwidgets/components/widgets/info_bar.py
@@ -7,11 +7,11 @@ from PyQt6.QtCore import (Qt, QEvent, QSize, QRectF, QObject, QPropertyAnimation
                           QEasingCurve, QTimer, pyqtSignal, QParallelAnimationGroup, QPoint)
 from PyQt6.QtGui import QPainter, QIcon, QColor
 from PyQt6.QtWidgets import (QWidget, QFrame, QLabel, QHBoxLayout, QVBoxLayout,
-                             QToolButton, QGraphicsOpacityEffect)
+                             QGraphicsOpacityEffect)
 
 from ...common.auto_wrap import TextWrap
 from ...common.style_sheet import FluentStyleSheet, themeColor
-from ...common.icon import FluentIconBase, Theme, isDarkTheme, writeSvg, drawSvgIcon, drawIcon
+from ...common.icon import FluentIconBase, Theme, isDarkTheme, drawIcon
 from ...common.icon import FluentIcon as FIF
 from .button import TransparentToolButton
 

--- a/qfluentwidgets/components/widgets/info_bar.py
+++ b/qfluentwidgets/components/widgets/info_bar.py
@@ -297,29 +297,16 @@ class InfoBar(QFrame):
 class InfoBarManager(QObject):
     """ Info bar manager """
 
-    _instance = None
     managers = {}
-
-    def __new__(cls, *args, **kwargs):
-        if cls._instance is None:
-            cls._instance = super(InfoBarManager, cls).__new__(
-                cls, *args, **kwargs)
-            cls._instance.__initialized = False
-
-        return cls._instance
 
     def __init__(self):
         super().__init__()
-        if self.__initialized:
-            return
-
         self.spacing = 16
         self.margin = 24
         self.infoBars = weakref.WeakKeyDictionary()
         self.aniGroups = weakref.WeakKeyDictionary()
         self.slideAnis = []
         self.dropAnis = []
-        self.__initialized = True
 
     def add(self, infoBar: InfoBar):
         """ add info bar """
@@ -430,7 +417,7 @@ class InfoBarManager(QObject):
         """
         def wrapper(Manager):
             if name not in cls.managers:
-                cls.managers[name] = Manager
+                cls.managers[name] = Manager()
 
             return Manager
 
@@ -442,7 +429,7 @@ class InfoBarManager(QObject):
         if position not in cls.managers:
             raise ValueError(f'`{position}` is an invalid animation type.')
 
-        return cls.managers[position]()
+        return cls.managers[position]
 
 
 @InfoBarManager.register(InfoBarPosition.TOP)


### PR DESCRIPTION
### Overview
This PR seeks to address the stack overflow issue described in #929.

### Description
The most notable change is that the base class `InfoBarManager` is no longer a singleton class. This does not pose a problem for the InfoBarManager class as a class method is the only method called by other objects (not counting inheritance). 
The change does, however, pose a problem for subclasses of InfoBarManager as they are dependant on the singleton pattern. This issue is resolved by letting the subclasses of InfoBarManager be implicit singletons, as their creation is managed by the InfoBarManager base class. When the already existing `register` decorator is used to decorate the subclasses, each subclass is now instantiated instead of just being a reference to the class. This ensures singleton behavior for each subclass managed by InfoBarManager while preventing the aforementioned stack overflow, although with a couple of downsides: 
* The initial loading time for the infobar module is slightly increased due to each subclass of InfoBarManager being instantiated immediately when the module is loaded, instead of being instantiated when needed (lazy loading).
* The memory usage for the infobar module is slightly increased in the case where only a few (or 0) types of InfoBarPosition are used, as they do not feature lazy loading anymore (though I can propose a solution for this if needed).

Aside from resolving the stack overflow, this solution does also have a benefit:
* After the initial loading, subsequent calls to InfoBarManager (i.e. when creating additional InfoBar objects) are slightly faster as a derived instance of InfoBarManager can be returned immediately when requested, instead of having to go through calls to `__new__` and `__init__` (in addition to their associated, internal methods).
