### PR TITLE
HexColorLineEdit 支持粘贴带有#前缀的十六进制颜色值

### DIFF
--- a/qfluentwidgets/components/dialog_box/color_dialog.py
+++ b/qfluentwidgets/components/dialog_box/color_dialog.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 from PyQt5.QtCore import Qt, pyqtSignal, QPoint, QRegExp, QSize
 from PyQt5.QtGui import (QBrush, QColor, QPixmap,
-                         QPainter, QPen, QIntValidator, QRegExpValidator, QIcon)
+                         QPainter, QPen, QIntValidator, QRegExpValidator, QIcon, QValidator)
 from PyQt5.QtWidgets import QApplication, QLabel, QWidget, QPushButton, QFrame, QVBoxLayout
 
 from ...common.style_sheet import FluentStyleSheet, isDarkTheme
@@ -190,6 +190,28 @@ class HexColorLineEdit(ColorLineEdit):
     def setColor(self, color):
         """ set color """
         self.setText(color.name(self.colorFormat)[1:])
+
+    def insertFromMimeData(self, source):
+        """Handle pasted data"""
+        text = source.text()
+        if text.startswith("#"):
+            text = text[1:]  # Remove the "#" prefix
+
+        state = self.validator().validate(text, 0)[0]
+        if state == QValidator.Acceptable:
+            self.setText(text)
+            self.textEdited.emit(text)
+        else:
+            super().insertFromMimeData(source)
+
+    def keyPressEvent(self, event):
+        """Handle the Ctrl+V paste shortcut"""
+        if event.key() == Qt.Key_V and event.modifiers() == Qt.ControlModifier:
+            clipboard = QApplication.clipboard()
+            mimeData = clipboard.mimeData()
+            self.insertFromMimeData(mimeData)
+        else:
+            super().keyPressEvent(event)
 
 
 class OpacityLineEdit(ColorLineEdit):


### PR DESCRIPTION
在使用第三方工具（如截图工具）获取十六进制颜色值时，这些颜色值通常会带有#前缀。在之前的代码中，用户需要手动删除这个#前缀后才能将颜色值粘贴到HexColorLineEdit中。

这个修改简化了这个流程，现在用户可以直接粘贴带有#前缀的十六进制颜色值，控件会自动删掉这个前缀并更新显示内容。