### PR TITLE
修复调用SegmentedWidget的clear方法错误(#975)

### DIFF
--- a/qfluentwidgets/components/navigation/pivot.py
+++ b/qfluentwidgets/components/navigation/pivot.py
@@ -176,6 +176,7 @@ class Pivot(QWidget):
             w.deleteLater()
 
         self.items.clear()
+        self._currentRouteKey = None
 
     def currentItem(self):
         """ Returns the current selected item """


### PR DESCRIPTION
- 在清空SegmentedWidget后应当在clear方法内将_currentRouteKey设置为None