### PR TITLE
修复导航栏在展开子项时无法自动扩展问题

### DIFF
--- a/qfluentwidgets/components/navigation/navigation_panel.py
+++ b/qfluentwidgets/components/navigation/navigation_panel.py
@@ -142,7 +142,7 @@ class NavigationPanel(QFrame):
         self.scrollLayout.setSpacing(4)
 
         self.vBoxLayout.addLayout(self.topLayout, 0)
-        self.vBoxLayout.addWidget(self.scrollArea, 1, Qt.AlignTop)
+        self.vBoxLayout.addWidget(self.scrollArea, 1)
         self.vBoxLayout.addLayout(self.bottomLayout, 0)
 
         self.vBoxLayout.setAlignment(Qt.AlignTop)
@@ -567,15 +567,6 @@ class NavigationPanel(QFrame):
 
     def isCollapsed(self):
         return self.displayMode == NavigationDisplayMode.COMPACT
-
-    def resizeEvent(self, e: QResizeEvent):
-        if e.oldSize().height() == self.height():
-            return
-
-        th = self.topLayout.minimumSize().height()
-        bh = self.bottomLayout.minimumSize().height()
-        h = self.height()-th-bh-20
-        self.scrollArea.setFixedHeight(max(h, 36))
 
     def eventFilter(self, obj, e: QEvent):
         if obj is not self.window() or not self._isCollapsible:


### PR DESCRIPTION
# 问题复现

**运行以下代码**

``` python
# coding:utf-8
import os
import sys
import yaml

from PyQt5.QtCore import Qt, QUrl
from PyQt5.QtGui import QIcon, QDesktopServices
from PyQt5.QtWidgets import QApplication, QFrame, QHBoxLayout
from qfluentwidgets import (NavigationItemPosition, MessageBox, setTheme, Theme, FluentWindow,
                            NavigationAvatarWidget, qrouter, SubtitleLabel, setFont, InfoBadge,
                            InfoBadgePosition)
from qfluentwidgets import FluentIcon as FIF


class Widget(QFrame):

    def __init__(self, text: str, parent=None):
        super().__init__(parent=parent)
        self.label = SubtitleLabel(text, self)
        self.hBoxLayout = QHBoxLayout(self)

        setFont(self.label, 24)
        self.label.setAlignment(Qt.AlignCenter)
        self.hBoxLayout.addWidget(self.label, 1, Qt.AlignCenter)
        self.setObjectName(text.replace(' ', '-'))


class Window(FluentWindow):

    def __init__(self):
        super().__init__()

        self.navigationInterface.setReturnButtonVisible(True)
        self.navigationInterface.setMenuButtonVisible(False)
        self.navigationInterface.setCollapsible(False)

        # create sub interface
        self.demo1 = Widget('demo1', self)
        self.demo2 = Widget('demo2', self)
        self.demo3 = Widget('demo3', self)
        self.demo4 = Widget('demo4', self)

        self.demo5 = Widget('demo5', self)
        self.demo6 = Widget('demo6', self)
        self.demo7 = Widget('demo7', self)
        self.demo8 = Widget('demo8', self)
        
        self.demo9 = Widget('demo9', self)
        self.demo10 = Widget('demo10', self)
        self.demo11 = Widget('demo11', self)
        self.demo12 = Widget('demo12', self)
        self.demo13 = Widget('demo13', self)

        self.demo14 = Widget('demo14', self)

        self.demo15 = Widget('demo15', self)
        self.demo16 = Widget('demo16', self)

        self.demo17 = Widget('demo17', self)

        self.initNavigation()
        self.initWindow()


    def initNavigation(self):
        self.addSubInterface(self.demo1, FIF.ALIGNMENT, 'demo1')
        self.addSubInterface(self.demo2, FIF.LIBRARY, 'demo2', parent=self.demo1)
        self.addSubInterface(self.demo3, FIF.LIBRARY, 'demo3', parent=self.demo1)
        self.addSubInterface(self.demo4, FIF.LIBRARY, 'demo4', parent=self.demo1)

        self.addSubInterface(self.demo5, FIF.ALIGNMENT, 'demo5')
        self.addSubInterface(self.demo6, FIF.LIBRARY, 'demo6', parent=self.demo5)
        self.addSubInterface(self.demo7, FIF.LIBRARY, 'demo7', parent=self.demo5)
        self.addSubInterface(self.demo8, FIF.LIBRARY, 'demo8', parent=self.demo5)

        self.addSubInterface(self.demo9, FIF.ALIGNMENT, 'demo9')
        self.addSubInterface(self.demo10, FIF.LIBRARY, 'demo10', parent=self.demo9)
        self.addSubInterface(self.demo11, FIF.LIBRARY, 'demo11', parent=self.demo9)
        self.addSubInterface(self.demo12, FIF.LIBRARY, 'demo12', parent=self.demo9)
        self.addSubInterface(self.demo13, FIF.LIBRARY, 'demo13', parent=self.demo9)

        self.addSubInterface(self.demo14, FIF.ALIGNMENT, 'demo14')

        self.addSubInterface(self.demo15, FIF.ALIGNMENT, 'demo15', NavigationItemPosition.SCROLL)
        self.addSubInterface(self.demo16, FIF.LIBRARY, 'demo16', parent=self.demo15, position=NavigationItemPosition.SCROLL)

        self.addSubInterface(self.demo17, FIF.ALIGNMENT, 'demo17', NavigationItemPosition.SCROLL)

    def initWindow(self):
        self.resize(900, 700)
        self.setWindowIcon(QIcon(':/qfluentwidgets/images/logo.png'))
        self.setWindowTitle('demo')

        desktop = QApplication.desktop().availableGeometry()
        w, h = desktop.width(), desktop.height()
        self.move(w//2 - self.width()//2, h//2 - self.height()//2)

    def showMessageBox(self):
        w = MessageBox(
            '支持作者🥰',
            '个人开发不易，如果这个项目帮助到了您，可以考虑请作者喝一瓶快乐水🥤。您的支持就是作者开发和维护项目的动力🚀',
            self
        )
        w.yesButton.setText('来啦老弟')
        w.cancelButton.setText('下次一定')

        if w.exec():
            QDesktopServices.openUrl(QUrl("https://afdian.net/a/zhiyiYo"))


if __name__ == '__main__':
    QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
    QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)

    # setTheme(Theme.DARK)

    app = QApplication(sys.argv)
    w = Window()
    w.show()
    app.exec_()
```
未展开导航栏子项时，窗口表现如图：
![image](https://github.com/user-attachments/assets/489318eb-51d8-469c-b1bf-e607776a41f5)

展开所有导航栏子项时，出现高度无法自动扩展而导致的**重叠问题**，如图：
![image](https://github.com/user-attachments/assets/d9daaec7-1191-4bf8-a8de-bce05742c2e1)

只有拖动窗口大小后，所有导航栏才能完整显示。

# 产生原因
`qfluentwidgets/components/navigation/navigation_panel.py` 中将导航栏划分为了三个部分，分别是**topLayout、scrollArea、bottomLayout**
在145行，使用如下语句添加scrollArea到布局中
`self.vBoxLayout.addWidget(self.scrollArea, 1, Qt.AlignTop)`
Qt.AlignTop使得scrollArea能够靠上布局，但是却导致了它的高度保持为了最小。为了使其高度能够填充除了topLayout和bottomLayout外的所有区域，不得不在571行重写了resizeEvent，如下：
``` python
    def resizeEvent(self, e: QResizeEvent):
        if e.oldSize().height() == self.height():
            return

        th = self.topLayout.minimumSize().height()
        bh = self.bottomLayout.minimumSize().height()
        h = self.height()-th-bh-20
        self.scrollArea.setFixedHeight(max(h, 36))
```
resizeEvent中使用了setFixedHeight方法设置了scrollArea的高度，这使得即使通过动画调整了位于topLayout中内容的高度，但是因为scrollArea高度保持了不变，导致topLayout无法自动增高。

# 解决办法
将145行，更改为
`self.vBoxLayout.addWidget(self.scrollArea, 1)`
由于其父布局为QHBoxLayout，故其自动靠上布局，且填充所有剩余区域，因此只需要将resizeEvent删除即可。

# 效果
![image](https://github.com/user-attachments/assets/009eab62-0bea-4f75-a15e-eaa4af8351e1)

不需要拖动窗口大小，所有导航栏均能完整显示。