### PR TITLE
fix: 操作 weakref 时出现的 RuntimeError 

### DIFF
--- a/qfluentwidgets/common/style_sheet.py
+++ b/qfluentwidgets/common/style_sheet.py
@@ -397,7 +397,7 @@ def updateStyleSheet(lazy=False):
         whether to update the style sheet lazily, set to `True` will accelerate theme switching
     """
     removes = []
-    for widget, file in styleSheetManager.items():
+    for widget, file in list(styleSheetManager.items()):
         try:
             if not (lazy and widget.visibleRegion().isNull()):
                 setStyleSheet(widget, file, qconfig.theme)


### PR DESCRIPTION
经测试 在 python 3.8 / 3.13 上均会概率性出现

```
2025-10-02 21:45:07.514 | ERROR    | __main__:global_exceptHook:181 - 发生全局异常:
├─异常类型: RuntimeError <class 'RuntimeError'>
├─异常信息: dictionary changed size during iteration
├─发生位置: weakref.py:431 in items
├─运行状态: 内存使用 222.7MB 线程数: 26
└─详细堆栈信息:
Traceback (most recent call last):

  File "main.py", line 3908, in <module>
    status = app.exec()
             │   └ <built-in method exec>
             └ <PyQt5.QtWidgets.QApplication object at 0x00000238BDFD0670>

  File "D:\Documents\GitHub\Class-Widgets\.venv\lib\site-packages\qfluentwidgets\components\widgets\menu.py", line 694, in _onItemClicked
    action.trigger()
    │      └ <built-in method trigger>
    └ <qfluentwidgets.common.icon.Action object at 0x00000238CBD31160>

> File "D:\Documents\GitHub\Class-Widgets\menu.py", line 2305, in <lambda>
    triggered=lambda: tip_toast.push_notification(
                      │         └ <function push_notification at 0x00000238C127C9D0>
                      └ <module 'tip_toast' from 'D:\\Documents\\GitHub\\Class-Widgets\\tip_toast.py'>

  File "D:\Documents\GitHub\Class-Widgets\tip_toast.py", line 564, in push_notification
    main(state, lesson_name, title, subtitle, content, icon, duration)
    │    │      │            │      │         │        │     └ 2000
    │    │      │            │      │         │        └ None
    │    │      │            │      │         └ None
    │    │      │            │      └ None
    │    │      │            └ None
    │    │      └ '信息技术'
    │    └ 1
    └ <function main at 0x00000238BE9C8E50>

  File "D:\Documents\GitHub\Class-Widgets\tip_toast.py", line 515, in main
    window = tip_toast((start_x, start_y), total_width, state, lesson_name, duration=duration)
             │          │        │         │            │      │                     └ 2000
             │          │        │         │            │      └ '信息技术'
             │          │        │         │            └ 1
             │          │        │         └ 1845
             │          │        └ 10
             │          └ 37
             └ <class 'tip_toast.tip_toast'>

  File "D:\Documents\GitHub\Class-Widgets\tip_toast.py", line 140, in __init__
    setThemeColor(f"#{config_center.read_conf('Color', 'attend_class')}")  # 主题色
    └ <function setThemeColor at 0x00000238BC5E7D30>

  File "D:\Documents\GitHub\Class-Widgets\.venv\lib\site-packages\qfluentwidgets\common\style_sheet.py", line 527, in setThemeColor
    updateStyleSheet(lazy)
    │                └ False
    └ <function updateStyleSheet at 0x00000238BC5E79D0>

  File "D:\Documents\GitHub\Class-Widgets\.venv\lib\site-packages\qfluentwidgets\common\style_sheet.py", line 400, in updateStyleSheet
    for widget, file in styleSheetManager.items():
        │       │       │                 └ <function StyleSheetManager.items at 0x00000238BC5D8790>
        │       │       └ <qfluentwidgets.common.style_sheet.StyleSheetManager object at 0x00000238BC5D8550>
        │       └ <qfluentwidgets.common.style_sheet.StyleSheetCompose object at 0x00000238C1A99BB0>
        └ <qfluentwidgets.components.widgets.button.PrimaryPushButton object at 0x00000238C1A9AA60>

  File "C:\Users\ishpd\AppData\Roaming\uv\python\cpython-3.8.20-windows-x86_64-none\lib\weakref.py", line 431, in items
    for wr, value in self.data.items():
        │   │        │    │    └ <method 'items' of 'dict' objects>
        │   │        │    └ {<weakref at 0x00000238C16A9630; to 'SystemTrayMenu' at 0x00000238C16E80D0>: <qfluentwidgets.common.style_sheet.StyleSheetCom...
        │   │        └ <WeakKeyDictionary at 0x238bc5e1250>
        │   └ <qfluentwidgets.common.style_sheet.StyleSheetCompose object at 0x00000238C1A99BB0>
        └ <weakref at 0x00000238C1A92B80; to 'PrimaryPushButton' at 0x00000238C1A9AA60>

RuntimeError: dictionary changed size during iteration
```