### PR TITLE
fix(color_dialog): cursor jumps to left at right edge

### DIFF
--- a/qfluentwidgets/components/dialog_box/color_dialog.py
+++ b/qfluentwidgets/components/dialog_box/color_dialog.py
@@ -31,7 +31,7 @@ class HuePanel(QWidget):
         """ set the position of  """
         self.pickerPos = pos
         self.color.setHsv(
-            int(max(0, min(1, pos.x() / self.width())) * 360),
+            int(max(0, min(1, pos.x() / self.width())) * 359),
             int(max(0, min(1, (self.height() - pos.y()) / self.height())) * 255),
             255
         )
@@ -43,7 +43,7 @@ class HuePanel(QWidget):
         self.color = QColor(color)
         self.color.setHsv(self.color.hue(), self.color.saturation(), 255)
         self.pickerPos = QPoint(
-            int(self.hue/360*self.width()),
+            int(self.hue/359*self.width()),
             int((255 - self.saturation)/255*self.height())
         )
         self.update()


### PR DESCRIPTION
# 颜色选择器光标位置修复

## 问题描述

在 ColorDialog 中 当用户将颜色选择光标移动至色相面板（HuePanel）最右端时，光标会异常跳转到最左端

## 主要变更

- **color_dialog.py**: 修正 `HuePanel` 类中色相值的计算范围
  - `setPickerPosition()`: 色相计算从 `0-360` 修正为 `0-359`
  - `setColor()`: 光标位置反向计算从 `/360` 修正为 `/359`



### 根本原因

QColor 的 HSV 色相（hue）有效范围是 **0-359**，而原代码使用了 `0-360` 范围：

当光标在最右端时：
1. 计算出 hue = 360
2. QColor 自动将 360 规范化为 0
3. 基于 hue=0 重新计算光标位置，导致跳转到最左端

<p align="center">
  <img src="https://github.com/user-attachments/assets/4174e0d5-de5f-4c19-9626-d419a66b3815" width="400px">
</p>



<p align="center">
  <strong>修复前</strong>
</p>





<p align="center">
  <img src="https://github.com/user-attachments/assets/bf91278c-6da9-4e50-b44d-a3849f3b082f" width="400px">
</p>




<p align="center">
  <strong>修复后</strong>
</p>