### PR TITLE
fix(navigation): stopIndicatorAnimation AttributeError

### DIFF
--- a/qfluentwidgets/components/navigation/navigation_panel.py
+++ b/qfluentwidgets/components/navigation/navigation_panel.py
@@ -645,7 +645,9 @@ class NavigationPanel(QFrame):
             return
 
         item.setSelected(True)
-        self._findIndicatorItem(item).setAboutSelected(False)
+        indicator_item = self._findIndicatorItem(item)
+        if indicator_item:
+            indicator_item.setAboutSelected(False)
         self.indicator.hide()
 
     def _onWidgetClicked(self):


### PR DESCRIPTION
在 navigationInterface 未 show 的时候 _findIndicatorItem 因 isVisible 不成立导致返回值为 None 后导致的  'NoneType' object has no attribute 'setAboutSelected'

附日志

```python
Traceback (most recent call last):

  File "main.py", line 4042, in <module>
    status = app.exec()
             │   └ <built-in method exec>
             └ <PyQt5.QtWidgets.QApplication object at 0x000002005F6DECA0>

  File "D:\Documents\GitHub\Class-Widgets\.venv\lib\site-packages\qfluentwidgets\components\widgets\button.py", line 82, in mouseReleaseEvent
    super().mouseReleaseEvent(e)
                              └ <PyQt5.QtGui.QMouseEvent object at 0x0000020062D47940>

> File "D:\Documents\GitHub\Class-Widgets\extra_menu.py", line 100, in <lambda>
    redirect_to_settings.clicked.connect(lambda: open_settings(self.main_window))
                                                 │             │    └ <__main__.DesktopWidget object at 0x0000020063492430>
                                                 │             └ <extra_menu.ExtraMenu object at 0x0000020063493670>
                                                 └ <function open_settings at 0x00000200632D7430>

  File "D:\Documents\GitHub\Class-Widgets\extra_menu.py", line 49, in open_settings
    settings = SettingsMenu(main_window=main_window)
               │                        └ <__main__.DesktopWidget object at 0x0000020063492430>
               └ <class 'menu.SettingsMenu'>

  File "D:\Documents\GitHub\Class-Widgets\menu.py", line 1277, in __init__
    self.init_window()
    │    └ <function SettingsMenu.init_window at 0x00000200632D7040>
    └ <menu.SettingsMenu object at 0x000002006F3300D0>

  File "D:\Documents\GitHub\Class-Widgets\menu.py", line 6223, in init_window
    self.navigationInterface.setCollapsible(False)
    │    │                   └ <function NavigationInterface.setCollapsible at 0x0000020060B1C700>
    │    └ <qfluentwidgets.components.navigation.navigation_interface.NavigationInterface object at 0x000002006F33F160>
    └ <menu.SettingsMenu object at 0x000002006F3300D0>

  File "D:\Documents\GitHub\Class-Widgets\.venv\lib\site-packages\qfluentwidgets\components\navigation\navigation_interface.py", line 344, in setCollapsible
    self.panel.setCollapsible(collapsible)
    │    │     │              └ False
    │    │     └ <function NavigationPanel.setCollapsible at 0x0000020060B11DC0>
    │    └ <qfluentwidgets.components.navigation.navigation_panel.NavigationPanel object at 0x000002006F33F1F0>
    └ <qfluentwidgets.components.navigation.navigation_interface.NavigationInterface object at 0x000002006F33F160>

  File "D:\Documents\GitHub\Class-Widgets\.venv\lib\site-packages\qfluentwidgets\components\navigation\navigation_panel.py", line 475, in setCollapsible
    self.expand(False)
    │    └ <function NavigationPanel.expand at 0x0000020060B150D0>
    └ <qfluentwidgets.components.navigation.navigation_panel.NavigationPanel object at 0x000002006F33F1F0>

  File "D:\Documents\GitHub\Class-Widgets\.venv\lib\site-packages\qfluentwidgets\components\navigation\navigation_panel.py", line 504, in expand
    self._stopIndicatorAnimation()
    │    └ <function NavigationPanel._stopIndicatorAnimation at 0x0000020060B151F0>
    └ <qfluentwidgets.components.navigation.navigation_panel.NavigationPanel object at 0x000002006F33F1F0>

  File "D:\Documents\GitHub\Class-Widgets\.venv\lib\site-packages\qfluentwidgets\components\navigation\navigation_panel.py", line 569, in _stopIndicatorAnimation
    self._onIndicatorAniFinished()
    │    └ <function NavigationPanel._onIndicatorAniFinished at 0x0000020060B155E0>
    └ <qfluentwidgets.components.navigation.navigation_panel.NavigationPanel object at 0x000002006F33F1F0>

  File "D:\Documents\GitHub\Class-Widgets\.venv\lib\site-packages\qfluentwidgets\components\navigation\navigation_panel.py", line 648, in _onIndicatorAniFinished
    self._findIndicatorItem(item).setAboutSelected(False)
    │    │                  └ <qfluentwidgets.components.navigation.navigation_widget.NavigationTreeWidget object at 0x0000020072C23DC0>
    │    └ <function NavigationPanel._findIndicatorItem at 0x0000020060B154C0>
    └ <qfluentwidgets.components.navigation.navigation_panel.NavigationPanel object at 0x000002006F33F1F0>

AttributeError: 'NoneType' object has no attribute 'setAboutSelected'
```