### PR TITLE
feat: add drag scroll api

### DIFF
--- a/examples/scroll/scroll_area/demo.py
+++ b/examples/scroll/scroll_area/demo.py
@@ -1,5 +1,7 @@
 # coding:utf-8
 import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 from PyQt5.QtCore import QEasingCurve, Qt
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import QApplication
@@ -19,6 +21,10 @@ class Demo(SmoothScrollArea):
         # customize scroll animation
         self.setScrollAnimation(Qt.Vertical, 400, QEasingCurve.OutQuint)
         self.setScrollAnimation(Qt.Horizontal, 400, QEasingCurve.OutQuint)
+
+        # drag content to scroll with left or right mouse button
+        self.setDragScrollEnabled(True)
+        self.setDragScrollButtons(Qt.LeftButton | Qt.RightButton)
 
         self.horizontalScrollBar().setValue(1900)
         self.setWidget(self.label)

--- a/qfluentwidgets/components/navigation/navigation_bar.py
+++ b/qfluentwidgets/components/navigation/navigation_bar.py
@@ -451,6 +451,20 @@ class NavigationBar(QWidget):
         for button in self.buttons():
             button.setSelectedColor(self.lightSelectedColor, self.darkSelectedColor)
 
+    def setDragScrollEnabled(self, isEnabled: bool):
+        """ set whether drag scroll is enabled """
+        self.scrollArea.setDragScrollEnabled(isEnabled)
+
+    def isDragScrollEnabled(self):
+        return self.scrollArea.isDragScrollEnabled()
+
+    def setDragScrollButtons(self, buttons):
+        """ set drag scroll mouse buttons """
+        self.scrollArea.setDragScrollButtons(buttons)
+
+    def dragScrollButtons(self):
+        return self.scrollArea.dragScrollButtons()
+
     def buttons(self):
         return [i for i in self.items.values() if isinstance(i, NavigationPushButton)]
 

--- a/qfluentwidgets/components/navigation/navigation_interface.py
+++ b/qfluentwidgets/components/navigation/navigation_interface.py
@@ -350,6 +350,20 @@ class NavigationInterface(QWidget):
         """ set whether the acrylic background effect is enabled """
         self.panel.setAcrylicEnabled(isEnabled)
 
+    def setDragScrollEnabled(self, isEnabled: bool):
+        """ set whether drag scroll is enabled """
+        self.panel.setDragScrollEnabled(isEnabled)
+
+    def isDragScrollEnabled(self):
+        return self.panel.isDragScrollEnabled()
+
+    def setDragScrollButtons(self, buttons):
+        """ set drag scroll mouse buttons """
+        self.panel.setDragScrollButtons(buttons)
+
+    def dragScrollButtons(self):
+        return self.panel.dragScrollButtons()
+
     def isIndicatorAnimationEnabled(self):
         return self.panel.isIndicatorAnimationEnabled()
 

--- a/qfluentwidgets/components/navigation/navigation_panel.py
+++ b/qfluentwidgets/components/navigation/navigation_panel.py
@@ -499,6 +499,20 @@ class NavigationPanel(QFrame):
         """ whether the acrylic effect is enabled """
         return self._isAcrylicEnabled
 
+    def setDragScrollEnabled(self, isEnabled: bool):
+        """ set whether drag scroll is enabled """
+        self.scrollArea.setDragScrollEnabled(isEnabled)
+
+    def isDragScrollEnabled(self):
+        return self.scrollArea.isDragScrollEnabled()
+
+    def setDragScrollButtons(self, buttons):
+        """ set drag scroll mouse buttons """
+        self.scrollArea.setDragScrollButtons(buttons)
+
+    def dragScrollButtons(self):
+        return self.scrollArea.dragScrollButtons()
+
     def expand(self, useAni=True):
         """ expand navigation panel """
         self._stopIndicatorAnimation()

--- a/qfluentwidgets/components/widgets/__init__.py
+++ b/qfluentwidgets/components/widgets/__init__.py
@@ -34,7 +34,7 @@ from .tree_view import TreeWidget, TreeView, TreeItemDelegate
 from .cycle_list_widget import CycleListWidget
 from .progress_bar import IndeterminateProgressBar, ProgressBar
 from .progress_ring import ProgressRing, IndeterminateProgressRing
-from .scroll_bar import ScrollBar, SmoothScrollBar, SmoothScrollDelegate, ScrollBarHandleDisplayMode
+from .scroll_bar import ScrollBar, SmoothScrollBar, SmoothScrollDelegate, ScrollBarHandleDisplayMode, DragScrollDelegate
 from .teaching_tip import TeachingTip, TeachingTipTailPosition, TeachingTipView, PopupTeachingTip
 from .flyout import FlyoutView, FlyoutViewBase, Flyout, FlyoutAnimationType, FlyoutAnimationManager
 from .tab_view import TabBar, TabItem, TabCloseButtonDisplayMode, TabWidget

--- a/qfluentwidgets/components/widgets/list_view.py
+++ b/qfluentwidgets/components/widgets/list_view.py
@@ -116,6 +116,20 @@ class ListBase:
         """
         self.delegate.setCheckedColor(light, dark)
 
+    def setDragScrollEnabled(self, isEnabled: bool):
+        """ set whether drag scroll is enabled """
+        self.scrollDelegate.setDragScrollEnabled(isEnabled)
+
+    def isDragScrollEnabled(self):
+        return self.scrollDelegate.isDragScrollEnabled()
+
+    def setDragScrollButtons(self, buttons):
+        """ set drag scroll mouse buttons """
+        self.scrollDelegate.setDragScrollButtons(buttons)
+
+    def dragScrollButtons(self):
+        return self.scrollDelegate.dragScrollButtons()
+
 
 class ListWidget(ListBase, QListWidget):
     """ List widget """

--- a/qfluentwidgets/components/widgets/scroll_area.py
+++ b/qfluentwidgets/components/widgets/scroll_area.py
@@ -5,7 +5,7 @@ from PyQt5.QtGui import QWheelEvent
 from PyQt5.QtWidgets import QScrollArea, QWidget
 
 from ...common.smooth_scroll import SmoothScroll, SmoothMode
-from .scroll_bar import ScrollBar, SmoothScrollBar, SmoothScrollDelegate
+from .scroll_bar import ScrollBar, SmoothScrollBar, SmoothScrollDelegate, DragScrollDelegate
 
 
 class ScrollArea(QScrollArea):
@@ -37,6 +37,20 @@ class ScrollArea(QScrollArea):
         if self.widget():
             self.widget().setStyleSheet("QWidget{background: transparent}")
 
+    def setDragScrollEnabled(self, isEnabled: bool):
+        """ set whether drag scroll is enabled """
+        self.scrollDelagate.setDragScrollEnabled(isEnabled)
+
+    def isDragScrollEnabled(self):
+        return self.scrollDelagate.isDragScrollEnabled()
+
+    def setDragScrollButtons(self, buttons):
+        """ set drag scroll mouse buttons """
+        self.scrollDelagate.setDragScrollButtons(buttons)
+
+    def dragScrollButtons(self):
+        return self.scrollDelagate.dragScrollButtons()
+
 
 class SingleDirectionScrollArea(QScrollArea):
     """ Single direction scroll area"""
@@ -56,6 +70,7 @@ class SingleDirectionScrollArea(QScrollArea):
         self.smoothScroll = SmoothScroll(self, orient)
         self.vScrollBar = SmoothScrollBar(Qt.Vertical, self)
         self.hScrollBar = SmoothScrollBar(Qt.Horizontal, self)
+        self.dragScrollDelegate = DragScrollDelegate(self, self.hScrollBar, self.vScrollBar)
 
     def setVerticalScrollBarPolicy(self, policy):
         super().setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
@@ -94,6 +109,20 @@ class SingleDirectionScrollArea(QScrollArea):
         if self.widget():
             self.widget().setStyleSheet("QWidget{background: transparent}")
 
+    def setDragScrollEnabled(self, isEnabled: bool):
+        """ set whether drag scroll is enabled """
+        self.dragScrollDelegate.setEnabled(isEnabled)
+
+    def isDragScrollEnabled(self):
+        return self.dragScrollDelegate.isEnabled()
+
+    def setDragScrollButtons(self, buttons):
+        """ set drag scroll mouse buttons """
+        self.dragScrollDelegate.setButtons(buttons)
+
+    def dragScrollButtons(self):
+        return self.dragScrollDelegate.buttons()
+
 
 class SmoothScrollArea(QScrollArea):
     """ Smooth scroll area """
@@ -124,3 +153,17 @@ class SmoothScrollArea(QScrollArea):
 
         if self.widget():
             self.widget().setStyleSheet("QWidget{background: transparent}")
+
+    def setDragScrollEnabled(self, isEnabled: bool):
+        """ set whether drag scroll is enabled """
+        self.delegate.setDragScrollEnabled(isEnabled)
+
+    def isDragScrollEnabled(self):
+        return self.delegate.isDragScrollEnabled()
+
+    def setDragScrollButtons(self, buttons):
+        """ set drag scroll mouse buttons """
+        self.delegate.setDragScrollButtons(buttons)
+
+    def dragScrollButtons(self):
+        return self.delegate.dragScrollButtons()

--- a/qfluentwidgets/components/widgets/scroll_bar.py
+++ b/qfluentwidgets/components/widgets/scroll_bar.py
@@ -1,10 +1,11 @@
 # coding:utf-8
 from enum import Enum
 from PyQt5.QtCore import (QEvent, QEasingCurve, Qt, pyqtSignal, QPropertyAnimation, pyqtProperty, QRectF,
-                          QTimer, QPoint, QObject)
+                          QTimer, QPoint, QObject, QItemSelection, QItemSelectionModel)
 from PyQt5.QtGui import QPainter, QColor, QMouseEvent
 from PyQt5.QtWidgets import (QWidget, QToolButton, QAbstractScrollArea, QGraphicsOpacityEffect,
-                             QHBoxLayout, QVBoxLayout, QApplication, QAbstractItemView, QListView)
+                             QHBoxLayout, QVBoxLayout, QApplication, QAbstractItemView, QListView,
+                             QAbstractButton)
 
 from ...common.icon import FluentIcon
 from ...common.style_sheet import isDarkTheme
@@ -600,6 +601,247 @@ class SmoothScrollBar(ScrollBar):
         self.ani.setEasingCurve(easing)
 
 
+class DragScrollDelegate(QObject):
+    """ Drag scroll delegate """
+
+    def __init__(self, parent: QAbstractScrollArea, hScrollBar=None, vScrollBar=None):
+        super().__init__(parent)
+        self.scrollArea = parent
+        self.hScrollBar = hScrollBar or parent.horizontalScrollBar()
+        self.vScrollBar = vScrollBar or parent.verticalScrollBar()
+
+        self._isEnabled = False
+        self._buttons = Qt.LeftButton
+        self._pressButton = Qt.NoButton
+        self._pressObj = None
+        self._pressPos = QPoint()
+        self._lastPos = QPoint()
+        self._isDragging = False
+        self._ignoreContextMenu = False
+        self._itemViewState = None
+        self._targets = []
+
+    def setEnabled(self, isEnabled: bool):
+        if isEnabled == self._isEnabled:
+            return
+
+        self._isEnabled = isEnabled
+        if isEnabled:
+            self.refresh()
+        else:
+            self._reset()
+            self._uninstall()
+
+    def isEnabled(self):
+        return self._isEnabled
+
+    def setButtons(self, buttons):
+        self._buttons = buttons
+        if self._pressButton != Qt.NoButton and not self._hasButton(self._pressButton):
+            self._reset()
+
+    def buttons(self):
+        return self._buttons
+
+    def refresh(self):
+        if not self._isEnabled:
+            return
+
+        self._install(self.scrollArea)
+        self._install(self.scrollArea.viewport())
+        self._installChildren(self.scrollArea.viewport())
+
+    def eventFilter(self, obj, e: QEvent):
+        if not self._isEnabled:
+            return super().eventFilter(obj, e)
+
+        if e.type() == QEvent.ChildAdded:
+            child = e.child()
+            if isinstance(child, QWidget):
+                self._installChildren(child)
+            return super().eventFilter(obj, e)
+
+        if e.type() == QEvent.ContextMenu and self._ignoreContextMenu:
+            self._ignoreContextMenu = False
+            return True
+
+        if e.type() == QEvent.MouseButtonPress:
+            self._ignoreContextMenu = False
+            return self._handleMousePress(obj, e)
+        if e.type() == QEvent.MouseMove:
+            return self._handleMouseMove(obj, e)
+        if e.type() == QEvent.MouseButtonRelease:
+            return self._handleMouseRelease(e)
+
+        return super().eventFilter(obj, e)
+
+    def _handleMousePress(self, obj, e: QMouseEvent):
+        if not self._hasButton(e.button()) or not self._canScroll():
+            return False
+
+        self._pressButton = e.button()
+        self._pressObj = obj
+        self._pressPos = self._mapToViewport(obj, e)
+        self._lastPos = QPoint(self._pressPos)
+        self._isDragging = False
+        self._saveItemViewState()
+        return False
+
+    def _handleMouseMove(self, obj, e: QMouseEvent):
+        if self._pressButton == Qt.NoButton or not (e.buttons() & self._pressButton):
+            self._reset()
+            return False
+
+        pos = self._mapToViewport(obj, e)
+        if not self._isDragging:
+            delta = pos - self._pressPos
+            if delta.manhattanLength() < QApplication.startDragDistance():
+                return False
+
+            self._isDragging = True
+            self._cancelPressedWidget()
+            self._restoreItemViewState()
+
+        dx = pos.x() - self._lastPos.x()
+        dy = pos.y() - self._lastPos.y()
+        self._lastPos = pos
+
+        if dx or dy:
+            self._scrollBy(dx, dy)
+
+        e.accept()
+        return True
+
+    def _handleMouseRelease(self, e: QMouseEvent):
+        if e.button() != self._pressButton:
+            return False
+
+        wasDragging = self._isDragging
+        wasRightButton = self._pressButton == Qt.RightButton
+        self._reset()
+
+        if not wasDragging:
+            return False
+
+        self._ignoreContextMenu = wasRightButton
+        e.accept()
+        return True
+
+    def _scrollBy(self, dx: int, dy: int):
+        if dy:
+            self._setBarValue(self.vScrollBar, self.vScrollBar.value() - dy)
+        if dx:
+            self._setBarValue(self.hScrollBar, self.hScrollBar.value() - dx)
+
+    def _setBarValue(self, bar, value: int):
+        value = max(bar.minimum(), min(value, bar.maximum()))
+        if value == bar.value():
+            return
+
+        if hasattr(bar, "ani"):
+            bar.ani.stop()
+        if hasattr(bar, "scrollTo"):
+            bar.scrollTo(value, False)
+        else:
+            bar.setValue(value)
+
+    def _cancelPressedWidget(self):
+        obj = self._pressObj
+        if not isinstance(obj, QWidget):
+            return
+
+        if isinstance(obj, QAbstractButton):
+            obj.setDown(False)
+        if hasattr(obj, "isPressed"):
+            obj.isPressed = False
+
+        obj.update()
+
+    def _saveItemViewState(self):
+        parent = self.scrollArea
+        self._itemViewState = None
+        if not isinstance(parent, QAbstractItemView):
+            return
+
+        selectionModel = parent.selectionModel()
+        if selectionModel is None:
+            return
+
+        self._itemViewState = (
+            selectionModel,
+            list(selectionModel.selectedIndexes()),
+            selectionModel.currentIndex(),
+        )
+
+    def _restoreItemViewState(self):
+        if self._itemViewState is None:
+            return
+
+        parent = self.scrollArea
+        selectionModel, indexes, currentIndex = self._itemViewState
+        selection = QItemSelection()
+        for index in indexes:
+            if index.isValid():
+                selection.select(index, index)
+
+        selectionModel.select(selection, QItemSelectionModel.ClearAndSelect)
+        if currentIndex.isValid():
+            selectionModel.setCurrentIndex(currentIndex, QItemSelectionModel.NoUpdate)
+        else:
+            selectionModel.clearCurrentIndex()
+
+        if hasattr(parent, "_setPressedRow"):
+            parent._setPressedRow(-1)
+        if hasattr(parent, "updateSelectedRows"):
+            parent.updateSelectedRows()
+
+    def _mapToViewport(self, obj, e: QMouseEvent):
+        viewport = self.scrollArea.viewport()
+        if obj == viewport:
+            return e.pos()
+
+        return viewport.mapFromGlobal(e.globalPos())
+
+    def _canScroll(self):
+        return self.vScrollBar.maximum() > self.vScrollBar.minimum() or \
+            self.hScrollBar.maximum() > self.hScrollBar.minimum()
+
+    def _hasButton(self, button):
+        return bool(button & self._buttons)
+
+    def _installChildren(self, widget: QWidget):
+        if isinstance(widget, QAbstractScrollArea):
+            return
+
+        self._install(widget)
+        for child in widget.findChildren(QWidget, options=Qt.FindDirectChildrenOnly):
+            self._installChildren(child)
+
+    def _install(self, obj):
+        if obj in self._targets:
+            return
+
+        obj.installEventFilter(self)
+        self._targets.append(obj)
+
+    def _uninstall(self):
+        for obj in self._targets:
+            try:
+                obj.removeEventFilter(self)
+            except RuntimeError:
+                pass
+
+        self._targets.clear()
+
+    def _reset(self):
+        self._pressButton = Qt.NoButton
+        self._pressObj = None
+        self._pressPos = QPoint()
+        self._lastPos = QPoint()
+        self._isDragging = False
+        self._itemViewState = None
+
+
 class SmoothScrollDelegate(QObject):
     """ Smooth scroll delegate """
 
@@ -619,6 +861,7 @@ class SmoothScrollDelegate(QObject):
         self.hScrollBar = SmoothScrollBar(Qt.Horizontal, parent)
         self.verticalSmoothScroll = SmoothScroll(parent, Qt.Vertical)
         self.horizonSmoothScroll = SmoothScroll(parent, Qt.Horizontal)
+        self.dragScrollDelegate = DragScrollDelegate(parent, self.hScrollBar, self.vScrollBar)
 
         if isinstance(parent, QAbstractItemView):
             parent.setVerticalScrollMode(QAbstractItemView.ScrollPerPixel)
@@ -667,4 +910,18 @@ class SmoothScrollDelegate(QObject):
     def setHorizontalScrollBarPolicy(self, policy):
         QAbstractScrollArea.setHorizontalScrollBarPolicy(self.parent(), Qt.ScrollBarAlwaysOff)
         self.hScrollBar.setForceHidden(policy == Qt.ScrollBarAlwaysOff)
+
+    def setDragScrollEnabled(self, isEnabled: bool):
+        """ set whether drag scroll is enabled """
+        self.dragScrollDelegate.setEnabled(isEnabled)
+
+    def isDragScrollEnabled(self):
+        return self.dragScrollDelegate.isEnabled()
+
+    def setDragScrollButtons(self, buttons):
+        """ set drag scroll mouse buttons """
+        self.dragScrollDelegate.setButtons(buttons)
+
+    def dragScrollButtons(self):
+        return self.dragScrollDelegate.buttons()
 

--- a/qfluentwidgets/components/widgets/table_view.py
+++ b/qfluentwidgets/components/widgets/table_view.py
@@ -246,6 +246,20 @@ class TableBase:
         """
         self.delegate.setCheckedColor(light, dark)
 
+    def setDragScrollEnabled(self, isEnabled: bool):
+        """ set whether drag scroll is enabled """
+        self.scrollDelagate.setDragScrollEnabled(isEnabled)
+
+    def isDragScrollEnabled(self):
+        return self.scrollDelagate.isDragScrollEnabled()
+
+    def setDragScrollButtons(self, buttons):
+        """ set drag scroll mouse buttons """
+        self.scrollDelagate.setDragScrollButtons(buttons)
+
+    def dragScrollButtons(self):
+        return self.scrollDelagate.dragScrollButtons()
+
     def _setHoverRow(self, row: int):
         """ set hovered row """
         self.delegate.setHoverRow(row)

--- a/qfluentwidgets/components/widgets/tree_view.py
+++ b/qfluentwidgets/components/widgets/tree_view.py
@@ -185,6 +185,20 @@ class TreeViewBase:
         qss = f"QTreeView{{border-radius: {radius}px}}"
         setCustomStyleSheet(self, qss, qss)
 
+    def setDragScrollEnabled(self, isEnabled: bool):
+        """ set whether drag scroll is enabled """
+        self.scrollDelagate.setDragScrollEnabled(isEnabled)
+
+    def isDragScrollEnabled(self):
+        return self.scrollDelagate.isDragScrollEnabled()
+
+    def setDragScrollButtons(self, buttons):
+        """ set drag scroll mouse buttons """
+        self.scrollDelagate.setDragScrollButtons(buttons)
+
+    def dragScrollButtons(self):
+        return self.scrollDelagate.dragScrollButtons()
+
 
 class TreeWidget(QTreeWidget, TreeViewBase):
     """ Tree widget """


### PR DESCRIPTION
# Drag Scroll API


添加长按鼠标左键或右键并上下/左右移动来滚动内容的 API，支持滚动区域、列表、表格、树视图以及导航侧边栏 
默认关闭，可配置只左键、只右键或左右键同时启用

## API

### ScrollArea.setDragScrollEnabled()

```python
def setDragScrollEnabled(isEnabled: bool)
```


### ScrollArea.isDragScrollEnabled()

```python
def isDragScrollEnabled()
```


### ScrollArea.setDragScrollButtons()

```python
def setDragScrollButtons(buttons)
```


### ScrollArea.dragScrollButtons()

```python
def dragScrollButtons()
```


## 用法

### 启用左键 ＆ 右键拖动滚动

```python
from PyQt5.QtCore import Qt

scrollArea.setDragScrollEnabled(True)
scrollArea.setDragScrollButtons(Qt.LeftButton | Qt.RightButton)
```


## 支持组件

- `ScrollArea`
- `SmoothScrollArea`
- `SingleDirectionScrollArea`
- `ListWidget` / `ListView`
- `TableWidget` / `TableView`
- `TreeWidget` / `TreeView`
- `NavigationPanel`
- `NavigationInterface`
- `NavigationBar`



https://github.com/user-attachments/assets/c8c39436-4585-4796-9de0-383ee1cfbc0b



<p align="center"><strong>演示</strong></p>
