### PR TITLE
Fix indicator position calculation in pivot.py

### DIFF
--- a/qfluentwidgets/components/navigation/pivot.py
+++ b/qfluentwidgets/components/navigation/pivot.py
@@ -273,7 +273,7 @@ class Pivot(QWidget):
             return QRectF(0, self.height() - 3, self.indicatorLength(), 3)
 
         rect = item.geometry()
-        return QRectF(rect.x() - 8 + rect.width() // 2, self.height() - 3, self.indicatorLength(), 3)
+        return QRectF(rect.x() - self.indicatorLength() // 2 + rect.width() // 2, self.height() - 3, self.indicatorLength(), 3)
 
     def paintEvent(self, e):
         super().paintEvent(e)


### PR DESCRIPTION
将基于初始长度的硬编码偏移量（8）修正为基于当前长度的偏移量（self.indicatorLength() // 2）