### PR TITLE
fix: 修复 macOS 26+ 上 ToolTip 原生阴影渲染异常

### DIFF
--- a/qfluentwidgets/components/widgets/tool_tip.py
+++ b/qfluentwidgets/components/widgets/tool_tip.py
@@ -79,7 +79,8 @@ class ToolTip(QFrame):
         self.setAttribute(Qt.WA_TransparentForMouseEvents)
         self.setAttribute(Qt.WA_TranslucentBackground)
         self.setAttribute(Qt.WA_ShowWithoutActivating)
-        self.setWindowFlags(Qt.Tool | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint)
+        self.setWindowFlags(Qt.Tool | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint |
+                            Qt.NoDropShadowWindowHint)
         self.__setQss()
 
     def text(self):


### PR DESCRIPTION
问题现象：
在 macOS 26 (Tahoe) 系统上，ToolTip 组件边缘出现灰色矩形硬边套环，
叠加在自绘阴影之上，影响视觉效果。Windows 和 macOS 26 以下版本正常。

问题原因：
macOS 26 改变了半透明无边框窗口的原生 NSWindow 阴影渲染方式，不再是
柔和投影，而是沿窗口矩形描绘灰色硬边。ToolTip 的 setWindowFlags 缺少
NoDropShadowWindowHint，导致保留了原生阴影。

解决方案：
为 ToolTip.__init__ 的 setWindowFlags 添加 Qt.NoDropShadowWindowHint， 与 RoundMenu、Flyout、PopupTeachingTip 的现有实现保持一致。

影响范围：
- macOS 26+: 移除灰色硬边，保留自绘阴影效果
- macOS <26: 去除冗余的双重阴影（原生+自绘），视觉更轻盈
- Windows/Linux: 无影响（该标志仅 macOS 生效）

修复前：
<img width="182" height="100" alt="image" src="https://github.com/user-attachments/assets/32d31838-5ca1-48e6-9b41-ebe5679aa254" />

修复后：
<img width="187" height="98" alt="image" src="https://github.com/user-attachments/assets/1841e602-8571-419f-acc0-4d549d57e195" />
